### PR TITLE
feat: SetupCI - implement avo as an admin interface

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem "rails-i18n", "~> 7.0.8"
 
 gem "vonage", "~> 7.19"
 
+gem "avo", ">= 3.2.1"
+
 group :development, :test do
   gem "debug", platforms: %i[mri mingw x64_mingw]
   gem "factory_bot_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,9 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_link_to (1.0.5)
+      actionpack
+      addressable
     activejob (7.1.2)
       activesupport (= 7.1.2)
       globalid (>= 0.3.6)
@@ -82,6 +85,22 @@ GEM
       rake (>= 10.4, < 14.0)
     ansi (1.5.0)
     ast (2.4.2)
+    avo (3.3.3)
+      actionview (>= 6.1)
+      active_link_to
+      activerecord (>= 6.1)
+      activesupport (>= 6.1)
+      addressable
+      docile
+      dry-initializer
+      httparty
+      inline_svg
+      meta-tags
+      pagy
+      turbo-rails
+      turbo_power (>= 0.6.0)
+      view_component (>= 3.7.0)
+      zeitwerk (>= 2.6.12)
     base64 (0.2.0)
     bcrypt (3.1.20)
     better_errors (2.10.1)
@@ -129,8 +148,10 @@ GEM
       warden (~> 1.2.3)
     devise-i18n (1.12.0)
       devise (>= 4.9.0)
+    docile (1.4.0)
     drb (2.2.0)
       ruby2_keywords
+    dry-initializer (3.1.1)
     erubi (1.12.0)
     factory_bot (6.4.5)
       activesupport (>= 5.0.0)
@@ -146,12 +167,18 @@ GEM
       actioncable (>= 6.0.0)
       listen (>= 3.0.0)
       railties (>= 6.0.0)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.0.1)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
+    inline_svg (1.9.0)
+      activesupport (>= 3.0)
+      nokogiri (>= 1.6)
     io-console (0.7.1)
     irb (1.11.0)
       rdoc
@@ -177,6 +204,9 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+    meta-tags (2.20.0)
+      actionpack (>= 6.0.0, < 7.2)
+    method_source (1.0.0)
     mini_mime (1.1.5)
     minitest (5.20.0)
     minitest-reporters (1.6.1)
@@ -185,6 +215,7 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     msgpack (1.7.2)
+    multi_xml (0.6.0)
     multipart-post (2.3.0)
     mutex_m (0.2.0)
     net-imap (0.4.9.1)
@@ -206,6 +237,7 @@ GEM
     nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    pagy (6.4.3)
     parallel (1.24.0)
     parser (3.3.0.0)
       ast (~> 2.4.1)
@@ -349,9 +381,15 @@ GEM
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)
+    turbo_power (0.6.1)
+      turbo-rails (>= 1.3.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    view_component (3.10.0)
+      activesupport (>= 5.2.0, < 8.0)
+      concurrent-ruby (~> 1.0)
+      method_source (~> 1.0)
     vonage (7.19.0)
       multipart-post (~> 2.0)
       phonelib
@@ -384,6 +422,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
+  avo (>= 3.2.1)
   bcrypt (~> 3.1.20)
   better_errors
   binding_of_caller

--- a/app/avo/actions/resend_confirmation_email.rb
+++ b/app/avo/actions/resend_confirmation_email.rb
@@ -1,0 +1,15 @@
+class Avo::Actions::ResendConfirmationEmail < Avo::BaseAction
+  self.name = "Renvoyer le mail de confirmation"
+
+  def handle(**args)
+    query, fields, current_user, resource = args.values_at(:query, :fields, :current_user, :resource)
+
+    query.each do |record|
+      record.confirmation_sent_at = DateTime.now.utc
+
+      # TODO: Should resend a confirmation email to join the team
+    end
+
+    succeed "Parfait c'est envoyé!"
+  end
+end

--- a/app/avo/actions/resend_invitation_email.rb
+++ b/app/avo/actions/resend_invitation_email.rb
@@ -1,0 +1,13 @@
+class Avo::Actions::ResendInvitationEmail < Avo::BaseAction
+  self.name = "Renvoyer une invitation"
+
+  def handle(**args)
+    query, fields, current_user, resource = args.values_at(:query, :fields, :current_user, :resource)
+
+    query.each do |record|
+      # TODO: Should resend an invitation email to join the team
+    end
+
+    succeed "Parfait c'est envoyé!"
+  end
+end

--- a/app/avo/resources/contact.rb
+++ b/app/avo/resources/contact.rb
@@ -1,0 +1,24 @@
+class Avo::Resources::Contact < Avo::BaseResource
+    self.includes = []
+
+    def fields
+        field :id, as: :id
+        field :name, as: :text
+        field :email, as: :text
+        field :phone, as: :text
+        field "team", as: :text do
+            record.team.name
+        rescue
+            false
+        end
+        field :created_at,
+            as: :date,
+            format: "yyyy-LL-dd"
+        field :updated_at,
+            as: :date,
+            format: "yyyy-LL-dd"
+        if view.show?
+            field :team_id, as: :number
+        end
+    end
+end

--- a/app/avo/resources/conversation.rb
+++ b/app/avo/resources/conversation.rb
@@ -1,0 +1,13 @@
+class Avo::Resources::Conversation < Avo::BaseResource
+  self.includes = []
+
+  def fields
+    field :id, as: :id
+    field :contact_id, as: :number, hide_on: [ :index ]
+    field :read, as: :boolean
+    field :contact, as: :belongs_to
+    field :team, as: :belongs_to
+    field :messages, as: :has_many, visible: -> { resource.record.messages.any? }
+    field :agents, as: :has_and_belongs_to_many, visible: -> { resource.record.agents.any? }
+  end
+end

--- a/app/avo/resources/message.rb
+++ b/app/avo/resources/message.rb
@@ -17,8 +17,8 @@ class Avo::Resources::Message < Avo::BaseResource
         neutral: :unsent # gray
       },
       sortable: true
-    field :conversation, as: :belongs_to, sortable: true
-    field :sender, as: :belongs_to, polymorphic_as: :sender, types: [ ::User ], sortable: true
+    field :conversation, as: :belongs_to
+    field :sender, as: :belongs_to, polymorphic_as: :sender, types: [ ::User ]
     field :created_at,
       as: :date,
       format: "yyyy-LL-dd"

--- a/app/avo/resources/message.rb
+++ b/app/avo/resources/message.rb
@@ -1,0 +1,36 @@
+class Avo::Resources::Message < Avo::BaseResource
+  self.includes = []
+  # TODO: Did we keep the Message resource from the sidebar?
+
+  def fields
+    field :id, as: :id
+    # TODO: truncate the message if more than 10-15 character
+    field :content, as: :text
+    # TODO: Check whether the Status field in the documentation is more suitable than badge
+    field :status,
+      as: :badge,
+      options: {
+        info: :submitted, # blue
+        success: [ :delivered, :inbound ], # green
+        warning: :undeliverable, # yellow
+        danger: :rejected, # red
+        neutral: :unsent # gray
+      },
+      sortable: true
+    field :conversation, as: :belongs_to, sortable: true
+    field :sender, as: :belongs_to, polymorphic_as: :sender, types: [ ::User ], sortable: true
+    field :created_at,
+      as: :date,
+      format: "yyyy-LL-dd"
+    field :updated_at,
+      as: :date,
+      format: "yyyy-LL-dd"
+    if view.show?
+      field :provider_info, as: :text
+      field :conversation_id, as: :number
+      field :sender_type, as: :text
+      field :sender_id, as: :number
+      field :outbound_uuid, as: :text
+    end
+  end
+end

--- a/app/avo/resources/team.rb
+++ b/app/avo/resources/team.rb
@@ -1,9 +1,10 @@
 class Avo::Resources::Team < Avo::BaseResource
     # FIXME: The button to the show panel use the slug instead of the id even with this option
     # It could be related to the way the id is managed in the Team class.
-    self.id = :id
     self.includes = []
-    self.model_class = ::Team
+    self.find_record_method = -> {
+          id.to_i == 0 ? query.find_by_slug(id) : query.find(id)
+    }
 
     def fields
         field :id, as: :id, link_to_record: true

--- a/app/avo/resources/team.rb
+++ b/app/avo/resources/team.rb
@@ -1,0 +1,26 @@
+class Avo::Resources::Team < Avo::BaseResource
+    # FIXME: The button to the show panel use the slug instead of the id even with this option
+    # It could be related to the way the id is managed in the Team class.
+    self.id = :id
+    self.includes = []
+    self.model_class = ::Team
+
+    def fields
+        field :id, as: :id, link_to_record: true
+        field :name, as: :text
+        field :address, as: :text
+        field :slug, as: :text, name: "Identifiant unique"
+        field :created_at,
+            as: :date,
+            format: "yyyy-LL-dd"
+        if view.show?
+            field :updated_at,
+            as: :date,
+            format: "yyyy-LL-dd"
+            field :desc, as: :text
+            field :users, as: :has_many, through: :memberships, visible: -> { resource.record.users.any? }
+            field :contacts, as: :has_many, visible: -> { resource.record.contacts.any? }
+            field :conversations, as: :has_many, through: :contacts, visible: -> { resource.record.contacts.any? }
+        end
+    end
+end

--- a/app/avo/resources/team.rb
+++ b/app/avo/resources/team.rb
@@ -1,6 +1,4 @@
 class Avo::Resources::Team < Avo::BaseResource
-    # FIXME: The button to the show panel use the slug instead of the id even with this option
-    # It could be related to the way the id is managed in the Team class.
     self.includes = []
     self.find_record_method = -> {
           id.to_i == 0 ? query.find_by_slug(id) : query.find(id)

--- a/app/avo/resources/user.rb
+++ b/app/avo/resources/user.rb
@@ -1,0 +1,56 @@
+class Avo::Resources::User < Avo::BaseResource
+  self.includes = []
+
+  def fields
+    # Field template for user in the main page
+    field :id, as: :id, sortable: true, link_to_record: true
+    field :name, as: :text, sortable: true
+    field :email, as: :text, sortable: true
+    field "is admin", as: :boolean do
+      record.role != "user"
+    end
+    field :role, as: :select, enum: ::User.roles, display_with_value: true, sortable: true
+    field :created_at,
+      as: :date,
+      format: "yyyy-LL-dd",
+      sortable: true
+    field "is confirmed", as: :boolean do
+      record.confirmed_at.present?
+    rescue
+      false
+    end
+    # Field template only available in page show
+    if view.show?
+      field :confirmed_at,
+        as: :date,
+        format: "yyyy-LL-dd"
+      field :confirmation_sent_at,
+        as: :date,
+        format: "yyyy-LL-dd"
+      field :updated_at,
+        as: :date,
+        format: "yyyy-LL-dd"
+      field :remember_created_at,
+        as: :date,
+        format: "yyyy-LL-dd"
+      field :reset_password_sent_at,
+        as: :date,
+        format: "yyyy-LL-dd"
+      field :confirmation_token, as: :text
+      field :reset_password_token, as: :text
+      field :unconfirmed_email, as: :text, show_on: :index
+      field :messages, as: :has_many, visible: -> { resource.record.messages.any? }
+      field :conversations, as: :has_and_belongs_to_many, visible: -> { resource.record.conversations.any? }
+      field :teams, as: :has_many, through: :memberships, visible: -> { resource.record.teams.any? }
+    end
+      # TODO: Implemente reset password this line will not work
+      # Could be better to just resend an email for reset password?
+      field :password, as: :password
+  end
+
+  # Actions that can be performed on user
+  def actions
+    action Avo::Actions::ResendInvitationEmail
+    action Avo::Actions::ResendConfirmationEmail
+  end
+end

--- a/app/controllers/avo/contacts_controller.rb
+++ b/app/controllers/avo/contacts_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::ContactsController < Avo::ResourcesController
+end

--- a/app/controllers/avo/conversations_controller.rb
+++ b/app/controllers/avo/conversations_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::ConversationsController < Avo::ResourcesController
+end

--- a/app/controllers/avo/messages_controller.rb
+++ b/app/controllers/avo/messages_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::MessagesController < Avo::ResourcesController
+end

--- a/app/controllers/avo/teams_controller.rb
+++ b/app/controllers/avo/teams_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::TeamsController < Avo::ResourcesController
+end

--- a/app/controllers/avo/users_controller.rb
+++ b/app/controllers/avo/users_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::UsersController < Avo::ResourcesController
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,4 +53,8 @@ class User < ApplicationRecord
   def bestowable_roles
     ROLES[0..ROLES.index(role)]
   end
+
+  def is_authorize_on_avo
+    self.role == "site_admin" || self.role == "super_admin"
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,7 @@ Bundler.require(*Rails.groups)
 module CourtMessage
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
+    config.autoloader = :zeitwerk
     config.load_defaults 7.0
 
     # Configuration for the application, engines, and railties goes here.

--- a/config/initializers/avo.rb
+++ b/config/initializers/avo.rb
@@ -1,0 +1,146 @@
+# For more information regarding these settings check out our docs https://docs.avohq.io
+# The values disaplayed here are the default ones. Uncomment and change them to fit your needs.
+Avo.configure do |config|
+  ## == Routing ==
+  config.root_path = "/avo"
+  config.home_path = "/avo/resources/teams"
+  # used only when you have custom `map` configuration in your config.ru
+  # config.prefix_path = "/internal"
+
+  # Sometimes you might want to mount Avo's engines yourself.
+  # https://docs.avohq.io/3.0/routing.html
+  # config.mount_avo_engines = true
+
+  # Where should the user be redirected when visiting the `/avo` url
+  # config.home_path = nil
+
+  ## == Licensing ==
+  # config.license_key = ENV['AVO_LICENSE_KEY']
+
+  ## == Set the context ==
+  config.set_context do
+    # Return a context object that gets evaluated in Avo::ApplicationController
+  end
+
+  ## == Authentication ==
+  config.current_user_method do
+    Current.user
+  end
+  # config.current_user_method = {}
+  # config.authenticate_with do
+  # end
+
+  # == Devise ==
+  # config.current_user_method = :current_user
+  # config.authenticate_with do
+  #     redirect_to '/' unless Current.user.is_admin
+  # end
+  # config.current_user_method = :current_user
+
+  ## == Authorization ==
+  # config.authorization_methods = {
+  #   index: 'index?',
+  #   show: 'show?',
+  #   edit: 'edit?',
+  #   new: 'new?',
+  #   update: 'update?',
+  #   create: 'create?',
+  #   destroy: 'destroy?',
+  #   search: 'search?',
+  # }
+  # config.raise_error_on_missing_policy = false
+  # config.authorization_client = :pundit
+
+  ## == Localization ==
+  # config.locale = 'en-US'
+
+  ## == Resource options ==
+  # config.resource_controls_placement = :right
+  # config.model_resource_mapping = {}
+  # config.default_view_type = :table
+  # config.per_page = 24
+  # config.per_page_steps = [12, 24, 48, 72]
+  # config.via_per_page = 8
+  # config.id_links_to_resource = false
+
+  ## == Cache options ==
+  ## Provide a lambda to customize the cache store used by Avo.
+  ## We compute the cache store by default, this is NOT the default, just an example.
+  # config.cache_store = -> {
+  #   ActiveSupport::Cache.lookup_store(:solid_cache_store)
+  # }
+  # config.cache_resources_on_index_view = true
+  ## permanent enable or disable cache_resource_filters, default value is false
+  # config.cache_resource_filters = false
+  ## provide a lambda to enable or disable cache_resource_filters per user/resource.
+  # config.cache_resource_filters = -> { current_user.cache_resource_filters? }
+
+  ## == Logger ==
+  # config.logger = -> {
+  #   file_logger = ActiveSupport::Logger.new(Rails.root.join("log", "avo.log"))
+  #
+  #   file_logger.datetime_format = "%Y-%m-%d %H:%M:%S"
+  #   file_logger.formatter = proc do |severity, time, progname, msg|
+  #     "[Avo] #{time}: #{msg}\n".tap do |i|
+  #       puts i
+  #     end
+  #   end
+  #
+  #   file_logger
+  # }
+
+  ## == Customization ==
+  # config.app_name = 'Avocadelicious'
+  # config.timezone = 'UTC'
+  # config.currency = 'USD'
+  # config.hide_layout_when_printing = false
+  # config.full_width_container = false
+  # config.full_width_index_view = false
+  # config.search_debounce = 300
+  # config.view_component_path = "app/components"
+  # config.display_license_request_timeout_error = true
+  # config.disabled_features = []
+  # config.buttons_on_form_footers = true
+  # config.field_wrapper_layout = true
+  # config.resource_parent_controller = "Avo::ResourcesController"
+
+  ## == Branding ==
+  # config.branding = {
+  #   colors: {
+  #     background: "248 246 242",
+  #     100 => "#CEE7F8",
+  #     400 => "#399EE5",
+  #     500 => "#0886DE",
+  #     600 => "#066BB2",
+  #   },
+  #   chart_colors: ["#0B8AE2", "#34C683", "#2AB1EE", "#34C6A8"],
+  #   logo: "/avo-assets/logo.png",
+  #   logomark: "/avo-assets/logomark.png",
+  #   placeholder: "/avo-assets/placeholder.svg",
+  #   favicon: "/avo-assets/favicon.ico"
+  # }
+
+  ## == Breadcrumbs ==
+  # config.display_breadcrumbs = true
+  # config.set_initial_breadcrumbs do
+  #   add_breadcrumb "Home", '/avo'
+  # end
+
+  ## == Menus ==
+  # config.main_menu = -> {
+  #   section "Dashboards", icon: "dashboards" do
+  #     all_dashboards
+  #   end
+
+  #   section "Resources", icon: "resources" do
+  #     all_resources
+  #   end
+
+  #   section "Tools", icon: "tools" do
+  #     all_tools
+  #   end
+  # }
+  # config.profile_menu = -> {
+  #   link "Profile", path: "/avo/profile", icon: "user-circle"
+  # }
+end

--- a/config/initializers/avo.rb
+++ b/config/initializers/avo.rb
@@ -3,7 +3,7 @@
 Avo.configure do |config|
   ## == Routing ==
   config.root_path = "/avo"
-  config.home_path = "/avo/resources/teams"
+  config.home_path = "/avo/resources/users"
   # used only when you have custom `map` configuration in your config.ru
   # config.prefix_path = "/internal"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   get "/.internal/ui", to: "pages#show", id: "ui"
   resources :pages, only: [ :show ]
 
-  authenticate :user, ->(user) { user.is_authorize_on_avo } do
+  authenticate :user, ->(user) { Ability.new(user).can?(:manage, Team) } do
     mount Avo::Engine, at: Avo.configuration.root_path
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
   get "/.internal/ui", to: "pages#show", id: "ui"
   resources :pages, only: [ :show ]
 
+  authenticate :user, ->(user) { user.is_authorize_on_avo } do
+    mount Avo::Engine, at: Avo.configuration.root_path
+  end
+
   # User-facing routes
   devise_for :users, controllers: { registrations: "registrations" }
   devise_scope :user do


### PR DESCRIPTION
# General

Fixes #56

# Description

Add an administration panel to the application to access the database and perform a few simple requests, such as resending an invitation e-mail.

<img width="1311" alt="Screenshot 2024-02-07 at 18 05 56" src="https://github.com/louije/court-message/assets/16155041/1a36a8a9-8d87-411d-abd7-39fc95814866">

# Changes

- Add Gem avo
- Add in ressources:
    - User
    - Team
    - Contact
    - Conversation
    - Message
- All resources can be viewed, modified or deleted
- Two actions have been added to resend the confirmation mail or an invitation mail.

# Notes for the reviewer

###  rails_admin topic
I didn't manage to install rails_admin correctly, I left the option on a branch just in case. Avo seems to be a good solution, but I'm afraid the community version might block us at some point.

Some links on the issue:
https://github.com/sass/sass/issues/3269
https://github.com/railsadminteam/rails_admin/issues/3216
https://qiita.com/gogle184/items/204c652325636f868737

### Delivered

Everything doesn't work completely, in which case we decide to leave it as it is and come back to it later, even if it means modifying it according to our usage and the usage of the admins once they've tested it.

### Testing

I'd really appreciate it if you'd test it and let me know what you think 🤗 
- Go to the feature branch
- Run
```bash
bundle install
```
- Connect with an admin account -> `site_admin` or `super_admin` (You can use the one on the seed file if you use it 😄)
- Go on `http://localhost:3000/avo`
- Enjoy!
