### PR TITLE
feat/Avo - add membership to ressources

### DIFF
--- a/app/avo/resources/membership.rb
+++ b/app/avo/resources/membership.rb
@@ -1,0 +1,14 @@
+class Avo::Resources::Membership < Avo::BaseResource
+    self.includes = []
+
+    def fields
+        field :id, as: :id, link_to_record: true
+        field :team, as: :belongs_to
+        field :team_id, as: :id
+        field :user, as: :belongs_to
+        field :user_id, as: :id
+        field :created_at,
+            as: :date,
+            format: "yyyy-LL-dd"
+    end
+end

--- a/app/controllers/avo/memberships_controller.rb
+++ b/app/controllers/avo/memberships_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::MembershipsController < Avo::ResourcesController
+end


### PR DESCRIPTION
Membership visibility has already been added to users, but if a user is not part of any team, it is impossible to attach a team to him from his editor.

This screen disappear as soon as no team is attach
<img width="984" alt="Screenshot 2024-03-18 at 17 41 59" src="https://github.com/vivesvoies/court-message/assets/16155041/3095eca9-cdbe-4d58-9aa2-e549d18fdf07">
