### PR TITLE
feat: Add templates

### DIFF
--- a/app/assets/stylesheets/components/_templates.scss
+++ b/app/assets/stylesheets/components/_templates.scss
@@ -59,3 +59,10 @@
 .TemplateForm__remove {
   margin-right: auto;
 }
+
+.Template .cm-fieldset__element {
+  display: flex;
+}
+.Template .cm-fieldset__element .Template__content {
+  flex: 1;
+}

--- a/app/assets/stylesheets/components/_templates.scss
+++ b/app/assets/stylesheets/components/_templates.scss
@@ -4,9 +4,9 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 100%;
+  max-height: calc(var(--size-viewer) - var(--size-tab-bar));
   border-right: 0 solid var(--list-border);
-  overflow-y: scroll;
+  // overflow-y: auto;
 }
 
 ///
@@ -18,7 +18,8 @@
   margin: 0;
   width: 50%;
   text-align: center;
-  // background-color: var(--list-bg);}
+  // background-color: var(--list-bg);
+}
 .TemplatesHeader__actions {
   display: flex;
   margin: .5rem 0;
@@ -29,6 +30,7 @@
   margin: .5rem auto;
 }
 .TemplateList {
+  overflow-y: scroll;
 }
 
 ///
@@ -36,7 +38,8 @@
 ///
 
 .Template {
-  margin: 1rem auto;}
+  margin: 1rem auto;
+}
 
 .Template__content {
   margin: 2rem;

--- a/app/assets/stylesheets/components/_templates.scss
+++ b/app/assets/stylesheets/components/_templates.scss
@@ -47,19 +47,12 @@
 .Template__actions,
 .TemplateForm__actions {
   margin: 0 2rem;
+  display: flex;
+  align-items: space-between;
+  gap: .5rem;
 }
 
-.TemplateForm__cancel,
-.TemplateForm__remove,
-.TemplateForm__submit {
-  --width: 4;
-}
-
-.Template__remove {
-  --width: 7.5;
-}
-
-.Template__copy,
-.Template__edit {
-  --width: 1.5;
+.Template__remove,
+.TemplateForm__remove {
+  margin-right: auto;
 }

--- a/app/assets/stylesheets/components/_templates.scss
+++ b/app/assets/stylesheets/components/_templates.scss
@@ -1,0 +1,65 @@
+///
+
+.TemplateList {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  border-right: 0 solid var(--list-border);
+  overflow-y: scroll;
+}
+
+///
+/// Template list header
+///
+.TemplatesList__header h3 {
+  font: var(--font-small-bold);
+  padding: 1rem;
+  margin: 0;
+  width: 50%;
+  text-align: center;
+  // background-color: var(--list-bg);
+}
+.TemplatesListHeader__actions {
+  display: flex;
+  margin: .5rem 0;
+  border-bottom: 1px solid var(--list-separator);
+  padding-bottom: 2rem;
+}
+.TemplatesListHeader__new {
+  margin: .5rem auto;
+}
+
+///
+/// Template
+///
+
+.Template {
+  margin: 1rem auto;
+}
+
+.Template__content {
+  margin: 2rem;
+  margin-bottom: 0.5rem;
+  background-color: var(--list-template-bg);
+}
+
+.Template__actions,
+.TemplateForm__actions {
+  margin: 0 2rem;
+}
+
+.TemplateForm__cancel,
+.TemplateForm__remove,
+.TemplateForm__submit {
+  --width: 4;
+}
+
+.Template__remove {
+  --width: 7.5;
+}
+
+.Template__copy,
+.Template__edit {
+  --width: 1.5;
+}

--- a/app/assets/stylesheets/components/_templates.scss
+++ b/app/assets/stylesheets/components/_templates.scss
@@ -1,6 +1,6 @@
 ///
 
-.TemplateList {
+.Templates {
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -12,22 +12,23 @@
 ///
 /// Template list header
 ///
-.TemplatesList__header h3 {
+.Templates__header h3 {
   font: var(--font-small-bold);
   padding: 1rem;
   margin: 0;
   width: 50%;
   text-align: center;
-  // background-color: var(--list-bg);
-}
-.TemplatesListHeader__actions {
+  // background-color: var(--list-bg);}
+.TemplatesHeader__actions {
   display: flex;
   margin: .5rem 0;
   border-bottom: 1px solid var(--list-separator);
   padding-bottom: 2rem;
 }
-.TemplatesListHeader__new {
+.TemplatesHeader__new {
   margin: .5rem auto;
+}
+.TemplateList {
 }
 
 ///
@@ -35,8 +36,7 @@
 ///
 
 .Template {
-  margin: 1rem auto;
-}
+  margin: 1rem auto;}
 
 .Template__content {
   margin: 2rem;

--- a/app/assets/stylesheets/components/_viewer.scss
+++ b/app/assets/stylesheets/components/_viewer.scss
@@ -80,7 +80,7 @@
     .ViewerPrimary { display: inherit; }
     .ViewerSecondary { display: none; }
   }
-  .Viewer--tab-presents,
+  .Viewer--tab-presets,
   .Viewer--tab-inbox {
     .ViewerNavigation { display: none; }
     .ViewerPrimary { display: none; }

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -43,6 +43,7 @@
   --list-selected-bg: var(--color-peach);
   --list-active-bg: var(--color-peach-intense);
   --text-list-selected: var(--color-black);
+  --list-template-bg: var(--color-white);
 
   --menu-item-bg: var(--color-white);
   --menu-item-active: var(--color-latte);

--- a/app/avo/resources/template.rb
+++ b/app/avo/resources/template.rb
@@ -1,0 +1,10 @@
+class Avo::Resources::Template < Avo::BaseResource
+  self.includes = []
+
+  def fields
+    field :id, as: :id
+    field :title, as: :text
+    field :content, as: :textarea
+    field :user, as: :belongs_to
+  end
+end

--- a/app/avo/resources/user.rb
+++ b/app/avo/resources/user.rb
@@ -45,6 +45,7 @@ class Avo::Resources::User < Avo::BaseResource
       # TODO: Password modification is possible. Could be better to just resend an email for reset password?
       field :password, as: :password
       field :teams, as: :has_many, through: :memberships
+      field :templates, as: :has_many, visible: -> { resource.record.templates.any? }
   end
 
   # Actions that can be performed on user

--- a/app/controllers/avo/templates_controller.rb
+++ b/app/controllers/avo/templates_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/2.0/controllers.html
+class Avo::TemplatesController < Avo::ResourcesController
+end

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -48,7 +48,7 @@ class ContactsController < ApplicationController
   # PATCH/PUT team/:team_slug/contacts/:id
   def update
     if @contact.update(contact_params)
-      redirect_to edit_team_contact_path(@team, @contact), notice: I18n.t(".contacts.update.success")
+      redirect_to edit_team_contact_path(@team, @contact), notice: I18n.t("contacts.update.success")
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -4,6 +4,7 @@ class ConversationsController < ApplicationController
   before_action :set_team, only: %i[ index show ]
   before_action :all_conversations, only: %i[ index ]
   before_action :set_conversation, only: %i[ show ]
+  before_action :set_templates, only: %i[ index show ]
 
   authorize_resource :team
   authorize_resource
@@ -30,6 +31,10 @@ class ConversationsController < ApplicationController
 
   def set_team
     @team = Current.team || Team.find_by(slug: params[:team_id])
+  end
+
+  def set_templates
+    @templates = Current.user.templates if current_frame.nil?
   end
 
   # # Only allow a list of trusted parameters through.

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -1,9 +1,15 @@
 class TemplatesController < ApplicationController
+  layout "viewer"
+  
   before_action :set_templates, only: %i[ show new create edit update destroy ]
   before_action :set_template, only: %i[ show edit update destroy ]
-  before_action :set_team, only: %i[ show new create edit update ]
+  before_action :set_team, only: %i[ index show new create edit update ]
   before_action :set_user, only: %i[ show new create edit update ]
   load_and_authorize_resource
+
+  # GET /teams/:team_slug/users/:id/templates
+  def index
+  end
 
   # GET /teams/:team_slug/users/:id/templates/:id
   def show

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -1,6 +1,6 @@
 class TemplatesController < ApplicationController
   layout "viewer"
-  
+
   before_action :set_templates, only: %i[ show new create edit update destroy ]
   before_action :set_template, only: %i[ show edit update destroy ]
   before_action :set_team, only: %i[ index show new create edit update ]

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -1,0 +1,90 @@
+class TemplatesController < ApplicationController
+  before_action :set_templates, only: %i[ show new create edit update destroy ]
+  before_action :set_template, only: %i[ show edit update destroy ]
+  before_action :set_team, only: %i[ show new create edit update ]
+  before_action :set_user, only: %i[ show new create edit update ]
+  load_and_authorize_resource
+
+  # GET /teams/:team_slug/users/:id/templates/:id
+  def show
+  end
+
+  # GET /teams/:team_slug/users/:id/templates/new
+  def new
+    @template = Template.new(user_id: @user.id)
+  end
+
+  # POST team/:team_slug/users/:id/templates
+  def create
+    @template = Template.new(new_template_params)
+    @user.templates << @template
+
+    if @template.save
+      respond_to do |format|
+        format.html { redirect_to team_user_templates_path(@team, @user) }
+        format.turbo_stream {
+          flash.now[:notice] = I18n.t("templates.create.success")
+        }
+      end
+    elsif !@template.valid?
+      redirect_to team_user_templates_path(@team, @user), notice: I18n.t("templates.create.not_blank")
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  # GET /teams/:team_slug/users/:id/templates/edit
+  def edit
+  end
+
+  # PATCH/PUT team/:team_slug/users/:id/templates/:id
+  def update
+    respond_to do |format|
+      if @template.update(template_params)
+        format.html { redirect_to team_user_templates_path, notice: I18n.t("templates.update.template_updated") }
+        format.turbo_stream
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.turbo_stream { render turbo_stream: turbo_stream.replace(@template) }
+      end
+    end
+  end
+
+  # DELETE team/:team_slug/users/:id/templates/:id
+  def destroy
+    @template.destroy
+    respond_to do |format|
+      format.html { redirect_to team_user_templates_path, notice: I18n.t("templates.destroy.success") }
+      format.turbo_stream {
+        flash.now[:notice] = I18n.t("templates.destroy.success")
+      }
+    end
+  end
+
+  private
+
+  def set_templates
+    @templates = User.find(params[:user_id]).templates
+  end
+
+  def set_template
+    @template = Template.find(params[:id])
+  end
+
+  def set_user
+    @user = User.find(params[:user_id])
+  end
+
+  def set_team
+    @team = Current.team || Team.find_by(slug: params[:team_id])
+  end
+
+  # Only allow a list of trusted parameters through.
+  def template_params
+    params.fetch(:template, {}).permit(:content)
+  end
+
+  def new_template_params
+    params.fetch(:template, {}).permit(:content, :user_id)
+  end
+end

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -13,6 +13,7 @@ class TemplatesController < ApplicationController
 
   # GET /teams/:team_slug/users/:id/templates/:id
   def show
+    redirect_to team_user_templates_path(@team, @user)
   end
 
   # GET /teams/:team_slug/users/:id/templates/new

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "source" ]
+
+  copy() {
+    const content = this.sourceTarget.innerText;
+    navigator.clipboard.writeText(content);
+  }
+}

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -14,6 +14,7 @@ class Ability
     can :read, Conversation, belongs_to_team
     can :create, Message, belongs_to_team
     can :manage, Contact, belongs_to_team
+    can :manage, Template, user_id: user.id
     return unless user.at_least?(:team_admin)
 
     # Rules for team admins -> create teams, add members, manage members

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: templates
+#
+#  id         :bigint           not null, primary key
+#  content    :text
+#  title      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_templates_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class Template < ApplicationRecord
+  belongs_to :user
+
+  validates :content, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,6 +58,9 @@ class User < ApplicationRecord
   has_many :memberships, dependent: :destroy
   has_many :teams, through: :memberships
   has_many :contacts
+  has_many :templates, dependent: :destroy
+
+  after_create :add_default_template
 
   def at_least?(role)
     ROLES.index(role.to_s) <= ROLES.index(self.role)
@@ -87,5 +90,15 @@ class User < ApplicationRecord
 
   def can_be_deleted?
     !confirmed_at.present? && teams.empty? && messages.empty?
+  end
+
+  private
+
+  def add_default_template
+    default_template = Template.create(
+      title: I18n.t("activerecord.models.user.default_template.title"),
+      content: I18n.t("activerecord.models.user.default_template.content")
+    )
+    templates << default_template
   end
 end

--- a/app/views/application/_tab_bar.erb
+++ b/app/views/application/_tab_bar.erb
@@ -22,9 +22,8 @@
   %>
   <%= tab_for :presets,
     icon: :star,
-    mobile: :only,
     frame: :secondary,
-    destination: page_path("presets")
+    destination: team_user_templates_path(team_id: Current.team.id, user_id: Current.user.id)
   %>
   <%= tab_for :inbox,
     icon: :"chat-bubble",

--- a/app/views/application/_tab_bar.html.erb
+++ b/app/views/application/_tab_bar.html.erb
@@ -23,7 +23,7 @@
   <%= tab_for :presets,
     icon: :star,
     frame: :secondary,
-    destination: team_user_templates_path(team_id: Current.team.id, user_id: Current.user.id)
+    destination: team_user_templates_path(team_id: Current.team.slug, user_id: Current.user.id)
   %>
   <%= tab_for :inbox,
     icon: :"chat-bubble",

--- a/app/views/conversations/index.html.erb
+++ b/app/views/conversations/index.html.erb
@@ -8,3 +8,7 @@
 <%= content_for :primary do %>
   <%= render partial: "conversation_detail", locals: { conversation: @conversation } if @conversation %>
 <% end %>
+
+<%= content_for :secondary do %>
+  <%= render partial: "templates/templates_list", locals: { user: Current.user, templates: @templates } %>
+<% end if @templates %>

--- a/app/views/conversations/show.html.erb
+++ b/app/views/conversations/show.html.erb
@@ -10,3 +10,7 @@
 <%= content_for :primary do %>
   <%= render partial: "conversation_detail", locals: { conversation: @conversation } if @conversation %>
 <% end %>
+
+<%= content_for :secondary do %>
+  <%= render partial: "templates/templates_list", locals: { user: Current.user, templates: @templates } %>
+<% end if @templates %>

--- a/app/views/layouts/viewer.html.erb
+++ b/app/views/layouts/viewer.html.erb
@@ -18,6 +18,7 @@
     </div>
 
     <%= turbo_frame_tag :secondary, class: "ViewerSecondary", refresh: :morph do %>
+      <%= render partial: "templates/templates_list", locals: { user: Current.user, team: @team } %>
       <%= yield :secondary %>
     <% end %>
 

--- a/app/views/layouts/viewer.html.erb
+++ b/app/views/layouts/viewer.html.erb
@@ -18,7 +18,6 @@
     </div>
 
     <%= turbo_frame_tag :secondary, class: "ViewerSecondary", refresh: :morph do %>
-      <%= render partial: "templates/templates_list", locals: { user: Current.user, team: @team } %>
       <%= yield :secondary %>
     <% end %>
 

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: template, url: template.new_record? ? team_user_templates_path(team_id: @team.slug, user_id: @user.id) : team_user_template_path(@team, user_id: template.user.id, id: template.id)) do |form| %>
+  <% if template.errors.any? %>
+    <%= render partial: "model_errors", locals: { model: template } %>
+  <% end %>
+
+  <fieldset class="cm-fieldset">
+    <div class="cm-fieldset__element">
+      <%= form.text_field :content, class: "cm-tile Template__content" %>
+    </div>
+  </fieldset>
+
+  <div class="cm-container TemplateForm__actions">
+    <% unless template.new_record? %>
+      <div class="cm-column TemplateForm__remove">
+        <%= link_to "", team_user_template_path(@team, user_id: template.user.id, id: template.id),
+            data: {
+              turbo_method: :delete,
+              turbo_confirm: "Are you sure?" },
+            class: "cm-btn cm-icon-bin cm-btn--secondary" %>
+      </div>
+    <% end %>
+      <div class="cm-column TemplateForm__submit">
+        <%= button_tag t(".update"), type: 'submit', class: "cm-btn cm-btn--validate cm-btn--icon-left cm-icon-checkmark" %>
+      </div>
+  </div>
+
+<% end %>

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -9,9 +9,9 @@
     </div>
   </fieldset>
 
-  <div class="cm-container TemplateForm__actions">
+  <div class="TemplateForm__actions">
     <% unless template.new_record? %>
-      <div class="cm-column TemplateForm__remove">
+      <div class="TemplateForm__remove">
         <%= link_to "", team_user_template_path(@team, user_id: template.user.id, id: template.id),
             data: {
               turbo_method: :delete,
@@ -19,7 +19,7 @@
             class: "cm-btn cm-icon-bin cm-btn--secondary" %>
       </div>
     <% end %>
-      <div class="cm-column TemplateForm__submit">
+      <div class="TemplateForm__submit">
         <%= button_tag t(".update"), type: 'submit', class: "cm-btn cm-btn--validate cm-btn--icon-left cm-icon-checkmark" %>
       </div>
   </div>

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -1,27 +1,29 @@
-<%= form_with(model: template, url: template.new_record? ? team_user_templates_path(team_id: @team.slug, user_id: @user.id) : team_user_template_path(@team, user_id: template.user.id, id: template.id)) do |form| %>
-  <% if template.errors.any? %>
-    <%= render partial: "model_errors", locals: { model: template } %>
-  <% end %>
-
-  <fieldset class="cm-fieldset">
-    <div class="cm-fieldset__element">
-      <%= form.text_field :content, class: "cm-tile Template__content" %>
-    </div>
-  </fieldset>
-
-  <div class="TemplateForm__actions">
-    <% unless template.new_record? %>
-      <div class="TemplateForm__remove">
-        <%= link_to "", team_user_template_path(@team, user_id: template.user.id, id: template.id),
-            data: {
-              turbo_method: :delete,
-              turbo_confirm: "Are you sure?" },
-            class: "cm-btn cm-icon-bin cm-btn--secondary" %>
-      </div>
+<div class="Template">
+  <%= form_with(model: template, url: template.new_record? ? team_user_templates_path(team_id: @team.slug, user_id: @user.id) : team_user_template_path(@team, user_id: template.user.id, id: template.id)) do |form| %>
+    <% if template.errors.any? %>
+      <%= render partial: "model_errors", locals: { model: template } %>
     <% end %>
-      <div class="TemplateForm__submit">
-        <%= button_tag t(".update"), type: 'submit', class: "cm-btn cm-btn--validate cm-btn--icon-left cm-icon-checkmark" %>
-      </div>
-  </div>
 
-<% end %>
+    <fieldset class="cm-fieldset">
+      <div class="cm-fieldset__element">
+        <%= form.text_area :content, class: "cm-tile Template__content" %>
+      </div>
+    </fieldset>
+
+    <div class="TemplateForm__actions">
+      <% unless template.new_record? %>
+        <div class="TemplateForm__remove">
+          <%= link_to "", team_user_template_path(@team, user_id: template.user.id, id: template.id),
+              data: {
+                turbo_method: :delete,
+                turbo_confirm: "Are you sure?" },
+              class: "cm-btn cm-icon-bin cm-btn--secondary" %>
+        </div>
+      <% end %>
+        <div class="TemplateForm__submit">
+          <%= button_tag t(".update"), type: 'submit', class: "cm-btn cm-btn--validate cm-btn--icon-left cm-icon-checkmark" %>
+        </div>
+    </div>
+
+  <% end %>
+</div>

--- a/app/views/templates/_template.html.erb
+++ b/app/views/templates/_template.html.erb
@@ -5,8 +5,8 @@
         <%= template.content %>
       </div>
 
-      <div class="cm-container Template__actions">
-        <div class="cm-column Template__remove">
+      <div class="Template__actions">
+        <div class="Template__remove">
           <%= link_to "", team_user_template_path(@team, user_id: template.user.id, id: template.id),
               data: {
                 turbo_method: :delete,
@@ -14,11 +14,11 @@
               class: "cm-btn cm-icon-bin cm-btn--secondary" %>
         </div>
       
-        <div class="cm-column Template__copy">
+        <div class="Template__copy">
           <button data-action="clipboard#copy" class="cm-btn cm-icon-copy cm-btn--validate"></button>
         </div>
 
-        <div class="cm-column Template__edit">
+        <div class="Template__edit">
           <%= link_to "", edit_team_user_template_path(@team, user_id: template.user.id, id: template.id),
               class: "cm-btn cm-icon-pencil cm-btn--validate" %>
         </div>

--- a/app/views/templates/_template.html.erb
+++ b/app/views/templates/_template.html.erb
@@ -1,0 +1,28 @@
+<%= turbo_frame_tag template do %>
+  <div class="Template" id="<%= dom_id template %>">
+    <div data-controller="clipboard">
+      <div class="cm-tile Template__content" data-clipboard-target="source">
+        <%= template.content %>
+      </div>
+
+      <div class="cm-container Template__actions">
+        <div class="cm-column Template__remove">
+          <%= link_to "", team_user_template_path(@team, user_id: template.user.id, id: template.id),
+              data: {
+                turbo_method: :delete,
+                turbo_confirm: "Are you sure?" },
+              class: "cm-btn cm-icon-bin cm-btn--secondary" %>
+        </div>
+      
+        <div class="cm-column Template__copy">
+          <button data-action="clipboard#copy" class="cm-btn cm-icon-copy cm-btn--validate"></button>
+        </div>
+
+        <div class="cm-column Template__edit">
+          <%= link_to "", edit_team_user_template_path(@team, user_id: template.user.id, id: template.id),
+              class: "cm-btn cm-icon-pencil cm-btn--validate" %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/templates/_templates_list.html.erb
+++ b/app/views/templates/_templates_list.html.erb
@@ -1,23 +1,23 @@
-  <div class="TemplatesList">
-    <header class="TemplatesList__header">
-      <h3>
-        <i class="cm-icon-star cm-icon"></i>
-        <%= t(".my_templates") %>
-      </h3>
-    </header>
-    <div class="TemplatesListHeader__actions">
-
-      <%= link_to t(".new_template"),
-            new_team_user_template_path(user_id: user.id),
-            data: { turbo_frame: "new_template" },
-            class: "cm-btn cm-btn--validate cm-btn--icon-left cm-icon-plus TemplatesListHeader__new" %>
-      </div>
-
-      <div class="Template">
-        <%= turbo_frame_tag "new_template" %>
-
-        <%= turbo_frame_tag "templates" do %>
-          <%= render user.templates %>
-        <% end %>
-      </div>
+<%# locals: (user:, templates:) %>
+<div class="Templates">
+  <header class="Templates__header">
+    <h3>
+      <i class="cm-icon-star cm-icon"></i>
+      <%= t(".my_templates") %>
+    </h3>
+  </header>
+  <div class="TemplatesHeader__actions">
+    <%= link_to t(".new_template"),
+          new_team_user_template_path(user_id: user.id),
+          data: { turbo_frame: "new_template" },
+          class: "cm-btn cm-btn--validate cm-btn--icon-left cm-icon-plus TemplatesHeader__new"
+    %>
   </div>
+  <div class="TemplateList">
+    <%= turbo_frame_tag "new_template" %>
+
+    <%= turbo_frame_tag "templates" do %>
+      <%= render templates %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/templates/_templates_list.html.erb
+++ b/app/views/templates/_templates_list.html.erb
@@ -1,0 +1,23 @@
+  <div class="TemplatesList">
+    <header class="TemplatesList__header">
+      <h3>
+        <i class="cm-icon-star cm-icon"></i>
+        <%= t(".my_templates") %>
+      </h3>
+    </header>
+    <div class="TemplatesListHeader__actions">
+
+      <%= link_to t(".new_template"),
+            new_team_user_template_path(user_id: user.id),
+            data: { turbo_frame: "new_template" },
+            class: "cm-btn cm-btn--validate cm-btn--icon-left cm-icon-plus TemplatesListHeader__new" %>
+      </div>
+
+      <div class="Template">
+        <%= turbo_frame_tag "new_template" %>
+
+        <%= turbo_frame_tag "templates" do %>
+          <%= render user.templates %>
+        <% end %>
+      </div>
+  </div>

--- a/app/views/templates/create.turbo_stream.erb
+++ b/app/views/templates/create.turbo_stream.erb
@@ -1,2 +1,2 @@
 <%= turbo_stream.append "templates", partial: "templates/template", locals: { template: @template } %>
-<%= turbo_stream.remove "new_template" %>
+<%= turbo_stream.update "new_template" %>

--- a/app/views/templates/create.turbo_stream.erb
+++ b/app/views/templates/create.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.prepend "templates", partial: "templates/template", locals: { template: @template } %>
+<%= turbo_stream.remove "new_template" %>

--- a/app/views/templates/create.turbo_stream.erb
+++ b/app/views/templates/create.turbo_stream.erb
@@ -1,2 +1,2 @@
-<%= turbo_stream.prepend "templates", partial: "templates/template", locals: { template: @template } %>
+<%= turbo_stream.append "templates", partial: "templates/template", locals: { template: @template } %>
 <%= turbo_stream.remove "new_template" %>

--- a/app/views/templates/destroy.turbo_stream.erb
+++ b/app/views/templates/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove @template %>

--- a/app/views/templates/edit.html.erb
+++ b/app/views/templates/edit.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag @template do %>
+  <%= render "form", template: @template, team: @team, user: @user %>
+<% end %>

--- a/app/views/templates/index.html.erb
+++ b/app/views/templates/index.html.erb
@@ -1,0 +1,4 @@
+<%# used with `templates/new`route %>
+<%= content_for :secondary do %>
+  <%= render partial: "templates/templates_list", locals: { user: Current.user, team: @team } %> 
+<% end %>

--- a/app/views/templates/index.html.erb
+++ b/app/views/templates/index.html.erb
@@ -1,4 +1,4 @@
 <%# used with `templates/new`route %>
 <%= content_for :secondary do %>
-  <%= render partial: "templates/templates_list", locals: { user: Current.user, team: @team } %> 
+  <%= render partial: "templates/templates_list", locals: { user: Current.user, templates: @templates } %> 
 <% end %>

--- a/app/views/templates/new.html.erb
+++ b/app/views/templates/new.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag "new_template" do %>
+  <%= render "form", template: @template %>
+<% end %>

--- a/app/views/templates/show.html.erb
+++ b/app/views/templates/show.html.erb
@@ -1,0 +1,2 @@
+<%# used with `templates/new` and `/edit` route %>
+<%= render partial: "template", locals: { template: @template, team: @team, user: @user } %>

--- a/app/views/templates/show.html.erb
+++ b/app/views/templates/show.html.erb
@@ -1,2 +1,4 @@
 <%# used with `templates/new` and `/edit` route %>
-<%= render partial: "template", locals: { template: @template, team: @team, user: @user } %>
+<%= content_for :secondary do %>
+  <%= render partial: "template", locals: { template: @template, team: @team, user: @user } %>
+<% end %>

--- a/app/views/templates/update.turbo_stream.erb
+++ b/app/views/templates/update.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.update "template_#{@template.id}", @template %>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -35,6 +35,9 @@ fr:
       user:
         one: "L’utilisateur"
         other: "Les utilisateurs"
+        default_template:
+          title: "Example de template"
+          content: "Bonjour, je suis Marte Bellemare, votre médiatrice France Service. Voici le numéro auquel me joindre par sms uniquement. N’hésitez pas si vous avez des questions. J’utiliserai ce canal pour vous transmettre toutes informations utiles vous concernant."
     attributes:
       user:
         remember_me: Se souvenir de moi
@@ -196,7 +199,6 @@ fr:
       new_team: "Ajouter une équipe"
       create_then_add: "Vous devez enregistrer votre équipe avant d’y ajouter des membres."
     form:
-      update: "Enregistrer les modifications"
       create: "Créer l’équipe"
       save_error: "L’équipe n’a pas pu être enregistrée."
     edit:
@@ -243,4 +245,16 @@ fr:
 
   invitations:
     notice:
-      user_add_to_team: "Le membre à été ajouté à votre équipe"
+      user_add_to_team: "Le membre a été ajouté à votre équipe"
+
+  templates:
+    templates_list:
+      my_templates: "Mes modèles"
+      new_template: "Nouveau modèle"
+    create:
+      success: "Nouveau template enregistré."
+      not_blank: "Impossible de crée un modèle vide"
+    update:
+      template_updated: ""
+    form:
+      update: "Enregistrer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,9 @@ Rails.application.routes.draw do
       end
     end
     resources :contacts, only: [ :index, :show, :new, :edit, :create, :update, :destroy ]
-    resources :users, only: [ :show, :edit, :update ]
+    resources :users, only: [ :show, :edit, :update ] do
+      resources :templates, only: [ :new, :create, :show, :edit, :update, :create, :destroy ]
+    end
     devise_for :users, controllers: { invitations: "invitations" }
   end
   resources :memberships, only: [ :new, :create, :destroy ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
     end
     resources :contacts, only: [ :index, :show, :new, :edit, :create, :update, :destroy ]
     resources :users, only: [ :show, :edit, :update ] do
-      resources :templates, only: [ :new, :create, :show, :edit, :update, :create, :destroy ]
+      resources :templates, only: [ :index, :new, :create, :show, :edit, :update, :create, :destroy ]
     end
     devise_for :users, controllers: { invitations: "invitations" }
   end

--- a/db/migrate/20240318191023_create_templates.rb
+++ b/db/migrate/20240318191023_create_templates.rb
@@ -1,0 +1,11 @@
+class CreateTemplates < ActiveRecord::Migration[7.1]
+  def change
+    create_table :templates do |t|
+      t.string :title
+      t.text :content
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -88,6 +88,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_21_103044) do
     t.index ["slug"], name: "index_teams_on_slug", unique: true
   end
 
+  create_table "templates", force: :cascade do |t|
+    t.string "title"
+    t.text "content"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_templates_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "name"
@@ -125,4 +134,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_21_103044) do
   add_foreign_key "memberships", "teams"
   add_foreign_key "memberships", "users"
   add_foreign_key "messages", "conversations"
+  add_foreign_key "templates", "users"
 end

--- a/test/controllers/templates_controller_test.rb
+++ b/test/controllers/templates_controller_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+
+class TemplatesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @team = create(:team)
+    @user = create(:user, teams: [ @team ])
+    @template = create(:template, user: @user)
+    sign_in @user
+  end
+
+  test "should get new" do
+    get new_team_user_template_path(@team, @user)
+    assert_response :success
+  end
+
+  test "should create template" do
+    assert_difference("Template.count") do
+      post team_user_templates_path(@team, @user), params: { template: { content: "Template content" } }
+    end
+
+    assert_redirected_to team_user_templates_path(@team, @user)
+    # assert_equal I18n.t("templates.create.success") , flash[:notice]
+  end
+
+  test "should not create template without content" do
+    assert_no_difference("Template.count") do
+      post team_user_templates_path(@team, @user), params: { template: { content: nil } }
+    end
+
+    assert_redirected_to team_user_templates_path(@team, @user)
+    # assert_equal I18n.t("templates.create.not_blank"), flash[:notice]
+  end
+
+  test "should show template" do
+    get team_user_template_path(@team, @user, @template)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_team_user_template_path(@team, @user, @template)
+    assert_response :success
+  end
+
+  test "should update template" do
+    patch team_user_template_path(@team, @user, @template), params: { template: { content: "Updated template content" } }
+    assert_redirected_to team_user_templates_path(@team, @user)
+  end
+
+  test "should not update template with invalid content" do
+    patch team_user_template_path(@team, @user, @template), params: { template: { content: nil } }
+    assert_response :unprocessable_entity
+  end
+
+  test "should destroy template" do
+    assert_difference("Template.count", -1) do
+      delete team_user_template_path(@team, @user, @template)
+    end
+
+    assert_redirected_to team_user_templates_path(@team, @user)
+  end
+end

--- a/test/controllers/templates_controller_test.rb
+++ b/test/controllers/templates_controller_test.rb
@@ -33,7 +33,7 @@ class TemplatesControllerTest < ActionDispatch::IntegrationTest
 
   test "should show template" do
     get team_user_template_path(@team, @user, @template)
-    assert_response :success
+    assert_redirected_to(team_user_templates_path(@team, @user))
   end
 
   test "should get edit" do

--- a/test/factories/templates.rb
+++ b/test/factories/templates.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: templates
+#
+#  id         :bigint           not null, primary key
+#  content    :text
+#  title      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_templates_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+FactoryBot.define do
+  factory :template do
+    title { Faker::TvShows::BojackHorseman.tongue_twister }
+    content { Faker::TvShows::BojackHorseman.quote }
+    user
+  end
+end

--- a/test/models/template_test.rb
+++ b/test/models/template_test.rb
@@ -1,0 +1,56 @@
+# == Schema Information
+#
+# Table name: templates
+#
+#  id         :bigint           not null, primary key
+#  content    :text
+#  title      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_templates_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+require "test_helper"
+
+class TemplateTest < ActiveSupport::TestCase
+  test "should not be valid if content is nil" do
+    user = create(:user)
+    template = build(:template, user: user, content: nil)
+    assert_not template.valid?
+  end
+
+  test "should not be valid if empty content" do
+    user = create(:user)
+    template = build(:template, user: user, content: "")
+    assert_not template.valid?
+  end
+
+  test "should be valid with content" do
+    template = build(:template)
+    assert template.valid?
+    assert template.save
+  end
+
+  test "should be valid with valid attributes" do
+    user = create(:user)
+    template = create(:template, user:)
+    assert template.valid?
+  end
+
+  test "should be valid without a title" do
+    template = create(:template, title: "")
+    assert template.valid?
+  end
+
+  test "should belong to a user" do
+    association = Template.reflect_on_association(:user)
+    assert_equal :belongs_to, association.macro
+  end
+end


### PR DESCRIPTION
fixes #99

## Description:

The user must be able to have ready-made messages for use in a `Mes Modèles` panel.
These models must have:
- [x] One default template available on account creation
- [x] Adding new templates option
- [x] Copy template option
- [x] Edit template option
- [x] Delete template option
- [x] Add tests

## Changes:

- Adding a template class
- Addition of a controller associated with class
- Adding views : `edit`, `new`, `_form`, `_templates`, `_templates_list`, `show`
- Add a default template each time a user is created
- Creation of turbo_stream for create, update and destroy
- Add template front file
