### PR TITLE
Fixes on invitations

### DIFF
--- a/app/assets/stylesheets/components/_teams.scss
+++ b/app/assets/stylesheets/components/_teams.scss
@@ -50,6 +50,11 @@
   padding: 2.5rem;
   padding-top: 0;
   overflow-y: scroll;
-  height: 100%;
+  height: 90%;
   margin-bottom: 50px;
+}
+
+.TeamShow__actions {
+  padding: 2.5rem 0rem;
+  border-top: 1px solid var(--list-border);
 }

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -6,11 +6,12 @@ class InvitationsController < Devise::InvitationsController
 
   def create
     user = User.find_by(email: invite_params[:email])
+    part_of_team = user && user.belongs_to_team?(@team)
     # If the user is not a team member the membership is automatically created
     Membership.create(team: @team, user: User.find(invite_resource.id)) unless user && user.belongs_to_team?(@team)
     # If the user is confirmed no invitation is sent
     if user && !user.awaiting_invitation_reply?
-      if user.belongs_to_team?(@team)
+      if part_of_team
         redirect_to team_path(@team), notice: I18n.t("devise.invitations.user_already_in_the_team"); return
       end
       redirect_to team_path(@team), notice: I18n.t(".invitations.notice.user_add_to_team"); return

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -29,7 +29,6 @@ class Ability
     can :manage, User
     can :manage, Contact
     can :manage, Membership
-    can :manage, Conversation
     cannot :destroy, User, id: user.id
     return unless user.at_least?(:super_admin)
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -29,6 +29,7 @@ class Ability
     can :manage, User
     can :manage, Contact
     can :manage, Membership
+    can :manage, Conversation
     cannot :destroy, User, id: user.id
     return unless user.at_least?(:super_admin)
 

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -7,14 +7,13 @@
   <div class="TeamShow__members-list">
     <%= turbo_frame_tag "team_members" do %>
       <%= render @team.memberships %>
-
-      <section class="TeamShow__actions">
-        <%= turbo_frame_tag User.new %>
-        <%= link_to t(".add_member"),
-          new_user_team_invitation_path(@team),
-          data: { turbo_frame: dom_id(User.new) },
-          class: "cm-btn cm-btn--secondary cm-btn--icon-left cm-icon-plus"  if can? :create, User %>
-      </section>
     <% end %>
+  <section class="TeamShow__actions">
+    <%= turbo_frame_tag User.new %>
+    <%= link_to t(".add_member"),
+      new_user_team_invitation_path(@team),
+      data: { turbo_frame: dom_id(User.new) },
+      class: "cm-btn cm-btn--secondary cm-btn--icon-left cm-icon-plus"  if can? :create, User %>
+  </section>
   </div>
 <% end %>


### PR DESCRIPTION
## Description:

- fixes: #155
- When a user is not in the team to which he is invited, the notice "already in your team" is still displayed. This is because the membership was created before checking whether or not the user is in the same team

