### PR TITLE
Fix: Remove useless routes for template

### DIFF
--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -1,20 +1,11 @@
 class TemplatesController < ApplicationController
   layout "viewer"
 
-  before_action :set_templates, only: %i[ show new create edit update destroy ]
-  before_action :set_template, only: %i[ show edit update destroy ]
-  before_action :set_team, only: %i[ index show new create edit update ]
-  before_action :set_user, only: %i[ show new create edit update ]
+  before_action :set_templates, only: %i[ new create edit update destroy ]
+  before_action :set_template, only: %i[ edit update destroy ]
+  before_action :set_team, only: %i[ new create edit update ]
+  before_action :set_user, only: %i[ new create edit update ]
   load_and_authorize_resource
-
-  # GET /teams/:team_slug/users/:id/templates
-  def index
-  end
-
-  # GET /teams/:team_slug/users/:id/templates/:id
-  def show
-    redirect_to team_user_templates_path(@team, @user)
-  end
 
   # GET /teams/:team_slug/users/:id/templates/new
   def new

--- a/app/views/templates/index.html.erb
+++ b/app/views/templates/index.html.erb
@@ -1,4 +1,0 @@
-<%# used with `templates/new`route %>
-<%= content_for :secondary do %>
-  <%= render partial: "templates/templates_list", locals: { user: Current.user, templates: @templates } %> 
-<% end %>

--- a/app/views/templates/show.html.erb
+++ b/app/views/templates/show.html.erb
@@ -1,4 +1,0 @@
-<%# used with `templates/new` and `/edit` route %>
-<%= content_for :secondary do %>
-  <%= render partial: "template", locals: { template: @template, team: @team, user: @user } %>
-<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
     end
     resources :contacts, only: [ :index, :show, :new, :edit, :create, :update, :destroy ]
     resources :users, only: [ :show, :edit, :update ] do
-      resources :templates, only: [ :index, :new, :create, :show, :edit, :update, :create, :destroy ]
+      resources :templates, only: [ :new, :create, :edit, :update, :create, :destroy ]
     end
     devise_for :users, controllers: { invitations: "invitations" }
   end

--- a/test/controllers/templates_controller_test.rb
+++ b/test/controllers/templates_controller_test.rb
@@ -31,11 +31,6 @@ class TemplatesControllerTest < ActionDispatch::IntegrationTest
     # assert_equal I18n.t("templates.create.not_blank"), flash[:notice]
   end
 
-  test "should show template" do
-    get team_user_template_path(@team, @user, @template)
-    assert_redirected_to(team_user_templates_path(@team, @user))
-  end
-
   test "should get edit" do
     get edit_team_user_template_path(@team, @user, @template)
     assert_response :success


### PR DESCRIPTION
## Description

The `index` and `show` routes were not used for the template controller, so they have been removed, along with the corresponding views.