### PR TITLE
Fix prefetch when hover conversations

### DIFF
--- a/app/views/conversations/_conversation.html.erb
+++ b/app/views/conversations/_conversation.html.erb
@@ -1,3 +1,4 @@
+<meta name="turbo-prefetch" content="false">
 <%= turbo_stream_from "conversation_list_item_#{conversation.id}" %>
 <li class="Conversation <%= "Conversation--active" if @conversation == conversation %> Conversation--<%= conversation.status %>"
     data-conversation-list-target="conversation"


### PR DESCRIPTION
fixes #166 

## Description

It seems that this issue is created by prefetching conversations when hovering them.
The option: `turbo_prefetch: false` doesn't seems to work ont the link_to so I add a balise instead