### PR TITLE
fix: the edit team page displays the correct frames

### DIFF
--- a/app/views/teams/edit.html.erb
+++ b/app/views/teams/edit.html.erb
@@ -1,11 +1,14 @@
-<%= content_for :back do %>
-  <%= link_to t(".back"), teams_path, class: "cm-btn cm-btn--icon-left fr-icon-arrow-left-line" %>
+<%= content_for :primary do %>
+  <%= content_for :back do %>
+    <%= link_to t(".back"), teams_path, class: "cm-btn cm-btn--icon-left fr-icon-arrow-left-line" %>
+  <% end %>
+  <%= render partial: "main_menu" %>
+  <div class="Page Page__edit-team">
+    <div class="Block Block__edit-team">
+      <header class="Teams__header">
+        <h2><%= t(".edit") %></h2>
+      </header>
+      <%= render "form", team: @team %>
+    </div>
+  </div>
 <% end %>
-<%= render partial: "main_menu" %>
-<div class="Page Page__edit-team">
-  <div class="Block Block__edit-team">
-    <header class="Teams__header">
-      <h2><%= t(".edit") %></h2>
-    </header>
-    <%= render "form", team: @team %>
-</div>

--- a/app/views/teams/menu.html.erb
+++ b/app/views/teams/menu.html.erb
@@ -8,7 +8,7 @@
       <%# TODO: change to team_contacts_path on next merge %>
       <%= menu_for(:contacts, icon: :"address-book", destination: team_contacts_path(@team)) %>
       <%= menu_for(:team, icon: :team, destination: team_path(@team)) %>
-      <%= menu_for(:edit_team, icon: :settings, destination: team_path(@team)) if can? :update, Team %>
+      <%= menu_for(:edit_team, icon: :settings, destination: edit_team_path(@team)) if can? :update, Team %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
Fix of the edit team page frame and the menu link to it works