### PR TITLE
Rationalize flash in turbo context

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   include FlashHelper
   helper_method :current_frame
   helper_method :turbo_frame_request?
+  helper_method :turbo_stream_request?
 
   before_action :authenticate_user!
   before_action :set_current
@@ -34,5 +35,9 @@ class ApplicationController < ActionController::Base
 
   def current_frame
     request&.headers["Turbo-Frame"]
+  end
+
+  def turbo_stream_request?
+    "text/vnd.turbo-stream.html".in? request&.accept
   end
 end

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -33,8 +33,8 @@ class MembershipsController < ApplicationController
 
     # Delete the invitation if the user has been invited
     respond_to do |format|
-      format.turbo_stream
       format.html { redirect_to user.awaiting_invitation_reply? ? remove_user_team_invitation_path(@team, user.invitation_token) : team_path(@team), status: :see_other, notice: I18n.t("memberships.destroy.destroyed") }
+      format.turbo_stream { flash.now[:notice] = I18n.t("memberships.destroy.destroyed") }
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,7 +18,7 @@ class UsersController < ApplicationController
     respond_to do |format|
       if @user.update(user_params)
         format.html { redirect_to team_path(@team), notice: I18n.t("users.update.user_updated") }
-        format.turbo_stream
+        format.turbo_stream { flash.now[:notice] = I18n.t("users.update.user_updated") }
       else
         format.html { render :edit, status: :unprocessable_entity }
         format.turbo_stream { render turbo_stream: turbo_stream.replace(@user) }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,4 +36,8 @@ module ApplicationHelper
     conversation = @conversation || @contact&.conversation
     team_conversations_path(@team, selected: conversation&.id)
   end
+
+  def content_and_flash_for(frame)
+    content_for(frame) + content_for(:flash_stream) if content_for? frame
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,9 @@
 
   <body class="<%= yield(:body_class) %>">
     <%= turbo_frame_tag "modal" %>
-    <div class="FlashContainer" id="flash"><%= render "flash" %></div>
+    <%= turbo_frame_tag "flash", class: "FlashContainer" do %>
+      <%= render "flash" %>
+    <% end %>
     <main class="Main">
       <%= content_for?(:layout) ? yield(:layout) : yield %>
     </main>

--- a/app/views/layouts/viewer.html.erb
+++ b/app/views/layouts/viewer.html.erb
@@ -1,3 +1,6 @@
+<% content_for :flash_stream do %>
+  <%= render "turbo_flash" %>
+<% end %>
 <% content_for :body_class, "has-viewer-visible" %>
 <% content_for :layout do %>
   <div class="Viewer" id="viewer" data-controller="viewer" data-viewer-conversation-list-outlet=".ConversationList" data-viewer-tab-bar-outlet=".TabBar nav">
@@ -5,12 +8,12 @@
       <%= turbo_frame_tag :navigation, class: "ViewerNavigation", src: lazy_loaded_conversations_path, refresh: :morph %>
     <% else %>
       <%= turbo_frame_tag :navigation, class: "ViewerNavigation", refresh: :morph do %>
-        <%= yield :navigation %>
+        <%= content_and_flash_for(:navigation) %>
       <% end %>
     <% end %>
 
     <%= turbo_frame_tag :primary, class: "ViewerPrimary", refresh: :morph do %>
-      <%= yield :primary %>
+      <%= content_and_flash_for(:primary) %>
     <% end %>
 
     <%= content_tag :div, class: "ViewerUserMenu" do %>
@@ -18,7 +21,7 @@
     <% end if !turbo_frame_request? %>
 
     <%= turbo_frame_tag :secondary, class: "ViewerSecondary", refresh: :morph do %>
-      <%= yield :secondary %>
+      <%= content_and_flash_for(:secondary) %>
     <% end %>
 
     <%= turbo_frame_tag :tab_bar, class: "TabBar cm-tab-bar", refresh: :morph do %>

--- a/app/views/memberships/destroy.turbo_stream.erb
+++ b/app/views/memberships/destroy.turbo_stream.erb
@@ -1,1 +1,2 @@
 <%= turbo_stream.remove "membership_#{@membership.id}" %>
+<%= render "turbo_flash" %>

--- a/app/views/messages/create.turbo_stream.erb
+++ b/app/views/messages/create.turbo_stream.erb
@@ -1,3 +1,1 @@
-<% if @message.invalid? %>
-  <%= render "turbo_flash" %>
-<% end %>
+<%= render "turbo_flash" %>

--- a/app/views/templates/create.turbo_stream.erb
+++ b/app/views/templates/create.turbo_stream.erb
@@ -1,2 +1,3 @@
 <%= turbo_stream.append "templates", partial: "templates/template", locals: { template: @template } %>
 <%= turbo_stream.update "new_template" %>
+<%= render "turbo_flash" %>

--- a/app/views/templates/destroy.turbo_stream.erb
+++ b/app/views/templates/destroy.turbo_stream.erb
@@ -1,1 +1,2 @@
 <%= turbo_stream.remove @template %>
+<%= render "turbo_flash" %>

--- a/app/views/users/update.turbo_stream.erb
+++ b/app/views/users/update.turbo_stream.erb
@@ -1,1 +1,2 @@
 <%= turbo_stream.update "user_#{@user.id}", @user %>
+<%= render "turbo_flash" %>


### PR DESCRIPTION
Added a turbo_stream for the flash frame in the viewer layout. Ensures flash is always set in turbo frames.

Added calls to render the flash partial in every turbo_stream template. Couldn’t find a way to have a layout for turbo_streams.