### PR TITLE
feat: Add welcome page

### DIFF
--- a/app/assets/stylesheets/components/_invitations.scss
+++ b/app/assets/stylesheets/components/_invitations.scss
@@ -1,17 +1,9 @@
+@import "variables";
 
 .InvitationNew__form {
   border-bottom: 1px solid var(--page-border);
-  padding-bottom: 2rem;
-  margin-bottom: 2.5rem;
-}
-
-.InvitationEdit__actions {
-  display: flex;
-  align-items: center;
-}
-
-.InvitationEdit__phone {
-  width: 60%;
+  padding: 0 0 1rem 0;
+  margin: 0 0 1rem 0;
 }
 
 .InvitationEdit__submit {
@@ -19,22 +11,44 @@
   margin-top: 2rem;
 }
 
-.InvitationNew__logo {
+.InvitationNew__logo,
+.InvitationEdit__logo {
   height: 40%;
 }
 
-.InvitationNew__title {
+.InvitationNew__title,
+.InvitationEdit__title {
   margin-block-start: 3em;
 }
 
-.InvitationNew__team {
+.InvitationNew__team,
+.InvitationEdit__team {
   margin-block-end: 2.5em;
 }
 
-.InvitationNew {
-  display: grid;
-  grid-template-columns: 3fr 1fr;
-  grid-template-rows: 1fr;
-  gap: 2rem;
-  height: 10rem;
+.InvitationNew,
+.InvitationEdit__header {
+  display: none;
+}
+
+@media (min-width: $width-mid) {
+  .InvitationEdit .cm-tab-bar__header {
+      display: none;
+  }
+  .InvitationEdit__header {
+      display: grid;
+      grid-template-columns: 3fr 1fr;
+      grid-template-rows: 1fr;
+      gap: 2rem;
+      height: 10rem;
+  }
+  .InvitationNew__actions,
+  .InvitationEdit__actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+  .InvitationEdit__phone {
+    width: 60%;
+  }
 }

--- a/app/assets/stylesheets/components/_users.scss
+++ b/app/assets/stylesheets/components/_users.scss
@@ -52,15 +52,3 @@
 .UserForm__cancel-invitation {
   --width: 5;
 }
-
-.UserInvitation__form {
-  border-bottom: 1px solid var(--page-border);
-  padding: 0 0 1rem 0;
-  margin: 0 0 1rem 0;
-}
-
-.UserInvitation__actions {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}

--- a/app/assets/stylesheets/components/_welcome.scss
+++ b/app/assets/stylesheets/components/_welcome.scss
@@ -19,6 +19,10 @@
   align-self: flex-end; 
 }
 
+.Welcome__actions-create:not(.Welcome__actions-connect) {
+  margin: 2em 0;
+}
+
 .Welcome__actions-connect a {
   margin-top: 1em;
 }

--- a/app/assets/stylesheets/components/_welcome.scss
+++ b/app/assets/stylesheets/components/_welcome.scss
@@ -1,0 +1,35 @@
+@import "variables";
+
+.Welcome__actions {
+  --gap: 1rem;
+}
+
+.Welcome__text {
+  --width-mid: 10;
+  --width-huge: 8;
+  font: var(--font-message);
+}
+
+.Welcome__actions-create,
+.Welcome__actions-connect {
+  --width: 7;
+}
+
+.Welcome__actions-create {
+  align-self: flex-end; 
+}
+
+.Welcome__actions-connect a {
+  margin-top: 1em;
+}
+
+.Welcome__actions-connect label {
+  margin-left: 1em;
+}
+
+@media screen and (min-width: $width-mid) {
+  .Welcome__actions-create,
+  .Welcome__actions-connect {
+    --width: 3;
+  }  
+}

--- a/app/avo/resources/user.rb
+++ b/app/avo/resources/user.rb
@@ -49,6 +49,9 @@ class Avo::Resources::User < Avo::BaseResource
       field "has an invitation token", as: :boolean do
         record.invitation_token?
       end
+      field :invited_by_id, as: :id
+      # Only available on the community version see: https://docs.avohq.io/3.0/fields/record_link.html#use_resource
+      # field :invited_by_id, as: :record_link, use_resource: "Avo::Resources::User"
       field :messages, as: :has_many, visible: -> { resource.record.messages.any? }
       field :conversations, as: :has_and_belongs_to_many, visible: -> { resource.record.conversations.any? }
     end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -27,7 +27,8 @@ class InvitationsController < Devise::InvitationsController
     # FIXME: The set_team before_action and authorize_ressource does not work for an unknown reason
     @team = Team.find_by(slug: params[:team])
     unless Current.user.belongs_to_team?(@team)
-      raise CanCan::AccessDenied, "You are not authorized to invite users to this team."
+      redirect_to @team, notice: I18n.t(".invitations.notice.not_authorized")
+      return
     end
     super
   end
@@ -40,7 +41,8 @@ class InvitationsController < Devise::InvitationsController
 
     # This is to prevent a user from being invited to a team to which the current user does not belong
     unless Current.user.belongs_to_team?(@team)
-      raise CanCan::AccessDenied, "You are not authorized to invite users to this team."
+      redirect_to @team, notice: I18n.t(".invitations.notice.not_authorized")
+      return
     end
 
     # If the user is confirmed no invitation is sent

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -5,8 +5,15 @@ class InvitationsController < Devise::InvitationsController
     @invitation_token = params[:invitation_token]
     self.resource = resource_class.find_by_invitation_token(@invitation_token, true)
 
+    # If the token isn't valid or the resource doesn't exist
     unless resource
       redirect_to user_session_path(), notice: I18n.t(".devise.invitations.invitation_token_invalid")
+      return
+    end
+
+    # Check if the user is already authenticated
+    if user_signed_in?
+      redirect_to teams_path, notice: I18n.t(".devise.failure.already_authenticated")
       return
     end
 

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -23,7 +23,6 @@ class InvitationsController < Devise::InvitationsController
   end
 
   def new
-    # FIXME: The set_team before_action and authorize_ressource does not work for an unknown reason
     @team = Team.find_by(slug: params[:team])
     unless Current.user.belongs_to_team?(@team)
       redirect_to @team, notice: I18n.t(".invitations.notice.not_authorized")
@@ -33,7 +32,6 @@ class InvitationsController < Devise::InvitationsController
   end
 
   def create
-    # FIXME: The set_team before_action and authorize_ressource does not work for an unknown reason
     @team = Team.find_by(slug: params[:team])
     user = User.find_by(email: invite_params[:email])
     part_of_team = user && user.belongs_to_team?(@team)
@@ -60,7 +58,6 @@ class InvitationsController < Devise::InvitationsController
   end
 
   def after_invite_path_for(resource)
-    # FIXME: The set_team before_action and authorize_ressource does not work for an unknown reason
     team_url(Team.find_by(slug: params[:team]))
   end
 

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,6 +1,21 @@
 class InvitationsController < Devise::InvitationsController
   before_action :configure_permitted_parameters
 
+  def welcome
+    @invitation_token = params[:invitation_token]
+    self.resource = resource_class.find_by_invitation_token(@invitation_token, true)
+
+    unless resource
+      redirect_to user_session_path(), notice: I18n.t(".devise.invitations.invitation_token_invalid")
+      return
+    end
+
+    @invited_by__name = User.find(resource.invited_by_id)
+    @team = Team.find(User.find(resource.id).team_ids.first).name
+    @is_admin = resource.role != "user"
+    render :welcome
+  end
+
   def new
     # FIXME: The set_team before_action and authorize_ressource does not work for an unknown reason
     @team = Team.find_by(slug: params[:team])

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -17,10 +17,9 @@ class InvitationsController < Devise::InvitationsController
       return
     end
 
-    @invited_by__name = User.find(resource.invited_by_id)
+    @invited_by = User.find(resource.invited_by_id)
     @team = Team.find(User.find(resource.id).team_ids.first).name
     @is_admin = resource.role != "user"
-    render :welcome
   end
 
   def new

--- a/app/javascript/controllers/debouncer_controller.js
+++ b/app/javascript/controllers/debouncer_controller.js
@@ -1,13 +1,11 @@
-import { Controller } from "@hotwired/stimulus"
+import { Controller } from "@hotwired/stimulus";
 
 // Connects to data-controller="debouncer"
 export default class extends Controller {
   debounceSubmit() {
-    console.log("ping")
-    clearTimeout(this.timeout)
+    clearTimeout(this.timeout);
     this.timeout = setTimeout(() => {
-      console.log("pong")
-      this.element.requestSubmit()
-    }, 200)
+      this.element.requestSubmit();
+    }, 200);
   }
 }

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,49 +1,55 @@
-<div class="Block">
-  <header class="InvitationNew cm-column cm-col--full">
-    <div>
-      <h2 class="InvitationNew__title"><%= t(".title") %></h2>
-    </div>
-    <%= image_tag "cm-logo.svg", class: "InvitationNew__logo",  alt: t(".logo-alt") %>
-  </header>
-
-  <%= t(".team") %>
-  <h4 class="InvitationNew__team">
-    <%= Team.find(User.find(resource.id).team_ids.first).name %>
-  </h4>
-  <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :invitation_token, readonly: true %>
-
-    <div class="cm-fieldset__element cm-input-group">
-      <%= f.label :name, t(:name), class: "Contact__label-name cm-label" %>
-      <%= f.text_field :name, class: "cm-input" %>
-    </div>
-
-    <div class="cm-fieldset__element cm-input-group">
-      <%= f.label :email, t(:email), class: "Contact__label-email cm-label" %>
-      <span class="cm-hint-text"><%= t(".email_format") %></span>
-      <%= f.text_field :email, class: "cm-input" %>
-    </div>
-
-  <% if f.object.class.require_password_on_accepting %>
-    <div class="cm-fieldset__element">
-      <%= f.label :password, class: "cm-label" %><br />
-      <%= f.password_field :password, class: "cm-input" %>
-    </div>
-    <div class="cm-fieldset__element">
-      <%= f.label :password_confirmation, class: "cm-label" %><br />
-      <%= f.password_field :password_confirmation, class: "cm-input" %>
-    </div>
+<div class="InvitationEdit">
+  <%= render "header_tab_bar" do %>
+    <%= t(".create_account") %>
   <% end %>
+  <div class="Block">
+    <header class="InvitationEdit__header cm-column cm-col--full">
+      <div>
+        <h2 class="InvitationEdit__title"><%= t(".title") %></h2>
+      </div>
+      <%= image_tag "cm-logo.svg", class: "InvitationEdit__logo",  alt: t(".logo-alt") %>
+    </header>
 
-  <div class="InvitationEdit__actions">
-    <div class="InvitationEdit__phone cm-fieldset__element cm-input-group">
-      <%= f.label :phone, t(:phone), class: "cm-label" %>
-      <span class="cm-hint-text"><%= t(".phone_format") %></span>
-      <%= f.text_field :phone, class: "cm-input" %>
-    </div>
-      <%= button_tag t(".create_account"), type: 'submit', class: "InvitationEdit__submit cm-btn" %>
+    <%= t(".team") %>
+    <h4 class="InvitationEdit__team">
+      <%= Team.find(User.find(resource.id).team_ids.first).name %>
+    </h4>
+
+    <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+      <%= f.hidden_field :invitation_token, readonly: true %>
+
+      <div class="cm-fieldset__element cm-input-group">
+        <%= f.label :name, t(:name), class: "Contact__label-name cm-label" %>
+        <%= f.text_field :name, class: "cm-input" %>
+      </div>
+
+      <div class="cm-fieldset__element cm-input-group">
+        <%= f.label :email, t(:email), class: "Contact__label-email cm-label" %>
+        <span class="cm-hint-text"><%= t(".email_format") %></span>
+        <%= f.text_field :email, class: "cm-input" %>
+      </div>
+
+      <% if f.object.class.require_password_on_accepting %>
+        <div class="cm-fieldset__element">
+          <%= f.label :password, class: "cm-label" %><br />
+          <%= f.password_field :password, class: "cm-input" %>
+        </div>
+        <div class="cm-fieldset__element">
+          <%= f.label :password_confirmation, class: "cm-label" %><br />
+          <%= f.password_field :password_confirmation, class: "cm-input" %>
+        </div>
+      <% end %>
+
+      <div class="InvitationEdit__actions">
+        <div class="InvitationEdit__phone cm-fieldset__element cm-input-group">
+          <%= f.label :phone, t(:phone), class: "cm-label" %>
+          <span class="cm-hint-text"><%= t(".phone_format") %></span>
+          <%= f.text_field :phone, class: "cm-input" %>
+        </div>
+          <%= button_tag t(".create_account"), type: 'submit', class: "InvitationEdit__submit cm-btn" %>
+      </div>
+    <% end %>
   </div>
+  <%= render partial: "footer" %>
 </div>
-<% end %>
-<%= render partial: "footer" %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -6,7 +6,7 @@
       <fieldset class="cm-fieldset">
         <div class="cm-fieldset__element cm-input-group">
           <%= f.label :name, t(:name), class: "cm-label" %>
-          <%= f.text_field :name, class: "cm-input" %>
+          <%= f.text_field :name, class: "cm-input", data: { controller: "autofocus" } %>
         </div>
 
         <% resource.class.invite_key_fields.each do |field| -%>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag @user do %>
-  <div class="UserInvitation__form">
+  <div class="InvitationNew__form">
     <%= form_for(resource, as: resource_name, url: user_invitation_path(team: params[:team]), html: { method: :post }) do |f| %>
       <%= render "devise/shared/error_messages", resource: resource %>
 
@@ -16,7 +16,7 @@
           </div>
         <% end -%>
 
-        <div class="UserInvitation__actions">
+        <div class="InvitationNew__actions">
           <%= button_tag t(".new"), type: "submit", class: "cm-btn cm-btn--validate cm-btn--icon-left cm-icon-checkmark", data: {turbo_frame: "_top"} %>
           <%= link_to t(:cancel), team_path(Team.find_by(slug: params[:team])), class: "cm-btn cm-btn--secondary" %> 
         </div>

--- a/app/views/devise/invitations/welcome.html.erb
+++ b/app/views/devise/invitations/welcome.html.erb
@@ -1,0 +1,31 @@
+<div class="cm-page">
+  <div class="cm-container">
+    <header class="SiteIntro cm-column cm-col--full">
+      <div>
+        <h1 class="SiteIntro__title"><%= t("text.welcome") %></h1>
+        <p class="SiteIntro__text">
+          <%= t("text.intro") %>
+        </p>
+      </div>
+      <%= image_tag "cm-logo.svg", class: "SiteIntro__logo",  alt: t(".logo-alt") %>
+    </header>
+
+    <p class="Welcome__text cm-column">
+      <%= t(".invite_text", invite_by: @invited_by__name, team: @team) %>
+    </p>
+
+    <div class="Welcome__actions cm-container">
+      <div class="Welcome__actions-create cm-column">
+        <%= link_to t(".sign_up"), accept_invitation_url(resource, invitation_token: @invitation_token), class: "cm-btn cm-btn--fat cm-btn--icon-left cm-icon-plus" %>
+      </div>
+      <% if @is_admin %>
+        <div class="Welcome__actions-connect cm-column">
+          <label class="cm-label"><%= t(".sign_in") %></label>
+          <%= link_to t(".connect"), user_session_path(), class: "cm-btn cm-btn--fat cm-btn--secondary cm-btn--icon-left cm-icon-arrow-right" %>
+        </div>
+      <% end %>
+    </div>
+
+  </div>
+</div>
+<%= render partial: "footer" %>

--- a/app/views/devise/invitations/welcome.html.erb
+++ b/app/views/devise/invitations/welcome.html.erb
@@ -11,7 +11,7 @@
     </header>
 
     <p class="Welcome__text cm-column">
-      <%= t(".invite_text", invite_by: @invited_by__name, team: @team) %>
+      <%= t(".invite_text", invited_by: @invited_by, team: @team) %>
     </p>
 
     <div class="Welcome__actions cm-container">

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p><%= User.find(@resource.invited_by_id).name %> vous a invité à rejoindre <%= t(:site_title) %>.</p>
 
-<p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, invitation_token: @token) %></p>
+<p><%= link_to t("devise.mailer.invitation_instructions.accept"), welcome_url(invitation_token: @token) %></p>
 
 <% if @resource.invitation_due_at %>
   <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %></p>

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -6,7 +6,7 @@
 
     <fieldset class="cm-fieldset">
       <div class="cm-fieldset__element">
-        <%= form.text_area :content, class: "cm-tile Template__content" %>
+        <%= form.text_area :content, class: "cm-tile Template__content", data: { controller: "autofocus" } %>
       </div>
     </fieldset>
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -33,6 +33,8 @@ fr:
     viewer_detail_tab_bar:
       conversations: "Messagerie"
       contacts: "Répertoire"
+    header_tab_bar:
+      create_account: "Créer mon compte"
 
   activerecord:
     models:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -65,7 +65,7 @@ fr:
           attributes:
             user:
               required: "n’a pas été sélectionné"
-      
+
   errors:
     messages:
       improbable_phone: "ne ressemble pas à un numéro valide"
@@ -110,10 +110,10 @@ fr:
         create_account: "Créer mon compte"
         team: "Équipe"
       welcome:
-          invite_text: "%{invite_by} vous a invité à rejoindre %{team}. Créez votre compte pour utiliser Court-message."
-          sign_up: "Créer mon compte"
-          sign_in: "J’ai déjà un compte ?"
-          connect: "Je me connecte"
+        invite_text: "%{invited_by} vous a invité à rejoindre %{team}. Créez votre compte pour utiliser Court-message."
+        sign_up: "Créer mon compte"
+        sign_in: "J’ai déjà un compte ?"
+        connect: "Je me connecte"
 
   date:
     yesterday: &yesterday "hier"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -107,6 +107,11 @@ fr:
         phone_format: "Format attendu : (+33) 6 22 33 44 55"
         create_account: "Créer mon compte"
         team: "Équipe"
+      welcome:
+          invite_text: "%{invite_by} vous a invité à rejoindre %{team}. Créez votre compte pour utiliser Court-message."
+          sign_up: "Créer mon compte"
+          sign_in: "J’ai déjà un compte ?"
+          connect: "Je me connecte"
 
   date:
     yesterday: &yesterday "hier"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -43,7 +43,7 @@ fr:
         other: "Les utilisateurs"
         default_template:
           title: "Example de template"
-          content: "Bonjour, ceci est un modèle de message. Vous pouvez me modifier et me conserver à votre guise afin d'avoir des réponses types prêtes à des demandes récurrentes"
+          content: "Bonjour, ceci est un modèle de message. Vous pouvez me modifier et me conserver à votre guise afin d’avoir des réponses types prêtes à des demandes récurrentes"
     attributes:
       user:
         remember_me: Se souvenir de moi
@@ -186,7 +186,7 @@ fr:
       last_contact: "Dernier contact créé dans l’équipe :"
     search:
       new_contact: "Nouveau contact"
-      no_contact: "Ce contact n'existe pas"
+      no_contact: "Ce contact n’existe pas"
       placeholder: "Rechercher votre contact"
 
   memberships:
@@ -270,6 +270,7 @@ fr:
   invitations:
     notice:
       user_add_to_team: "Le membre a été ajouté à votre équipe"
+      not_authorized: "Vous n’êtes pas autorisé à inviter des utilisateurs dans cette équipe"
 
   templates:
     templates_list:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { registrations: "registrations", invitations: "invitations" }
   devise_scope :user do
     get "/users/await-confirmation", to: "registrations#show", as: :await_confirmation
+    get "/users/welcome", to: "invitations#welcome", as: :welcome
   end
 
   resources :messages, only: [ :new, :create ]

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -19,7 +19,7 @@ class InvitationsControllerTest < ActionDispatch::IntegrationTest
     sign_in @user
     other_team = create(:team)
     get new_user_invitation_path(team: other_team)
-    assert_response :forbidden
+    assert_redirected_to team_url(other_team)
   end
 
   test "should create a new user when invited" do
@@ -128,7 +128,7 @@ class InvitationsControllerTest < ActionDispatch::IntegrationTest
     sign_in @other_user
 
     post user_invitation_path(team: @team), params: { user: { name: "John Doe", email: "john@example.com" } }
-    assert_response :forbidden
+    assert_redirected_to team_url(@team)
   end
 
   test "should redirect to team path if user is already authenticated" do

--- a/test/controllers/invitations_controller_test.rb
+++ b/test/controllers/invitations_controller_test.rb
@@ -137,9 +137,9 @@ class InvitationsControllerTest < ActionDispatch::IntegrationTest
     get welcome_url(invitation_token: "valid_token")
     assert_redirected_to user_session_url
   end
-  
+
   test "should render welcome page if user is not authenticated and token is valid" do
-    new_user = User.invite!(email: 'john@example.com', name: 'John Doe') do |u|
+    new_user = User.invite!(email: "john@example.com", name: "John Doe") do |u|
       u.skip_invitation = true
       u.invited_by_id = @user.id
     end
@@ -147,7 +147,7 @@ class InvitationsControllerTest < ActionDispatch::IntegrationTest
     get welcome_url(invitation_token: new_user.raw_invitation_token)
     assert_response :success
   end
-  
+
   test "should redirect to sign in path if user is not authenticated and token is invalid" do
     get welcome_url(invitation_token: "invalid_token")
     assert_redirected_to new_user_session_path


### PR DESCRIPTION
fixes #181
fixes #182

## Description

This is an addition to #192, it adds the home page before account creation when following the invitation link.

## Addition

- Creation of a `welcome` route
- Creation of a new page `Welcome`
- Creation of a new method welcome in the invitation controller
- Modification of the link in the invitation email