### PR TITLE
Change invitation expiration date

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,6 +92,10 @@ class User < ApplicationRecord
     !confirmed_at.present? && teams.empty? && messages.empty?
   end
 
+  def send_reset_password_instructions
+    super if invitation_token.nil?
+  end
+
   private
 
   def add_default_template

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -141,7 +141,7 @@ Devise.setup do |config|
   # The period the generated invitation token is valid.
   # After this period, the invited resource won't be able to accept the invitation.
   # When invite_for is 0 (the default), the invitation won't expire.
-  config.invite_for = 2.weeks
+  config.invite_for = 10.weeks
 
   # Number of invitations users can send.
   # - If invitation_limit is nil, there is no limit for invitations, users can


### PR DESCRIPTION
Fixes partially #249

### Changes:
- Set the expiry date at 10 weeks, which is just over 2 months.
- Also it is possible to create an account even if the invitation has expired I found [this point](https://github.com/scambra/devise_invitable/wiki/Disabling-devise-recoverable,-if-invitation-was-not-accepted) about it. The user model has been updated as follows.
