### PR TITLE
Fix error 500 when deleting a contact

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -38,7 +38,6 @@ class Contact < ApplicationRecord
 
   phony_normalize :phone
   validates :phone, presence: true, uniqueness: { scope: :team_id }, phony_plausible: true
-
   validates :email, uniqueness: { scope: :team_id }, allow_blank: true
 
   before_update :update_notes_information, if: :notes_changed?

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -66,7 +66,7 @@ class Conversation < ApplicationRecord
     if unread? # broadcast a new message
       broadcast_remove_to "conversation_list_item_#{id}"
       broadcast_prepend_to "team_conversations_list_#{team.id}", partial: "conversations/conversation", locals: { conversation: self }
-    else # broadcast another upddate (such as change in read / unread status)
+    else # broadcast another update (such as change in read / unread status)
       broadcast_replace_to "conversation_list_item_#{id}", partial: "conversations/conversation", locals: { conversation: self }
     end
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -36,6 +36,7 @@ class Message < ApplicationRecord
   belongs_to :conversation, touch: true
   belongs_to :sender, polymorphic: true
   delegate :team, to: :conversation
+  before_destroy :nullify_last_message
 
   validates_presence_of :content
 
@@ -43,5 +44,10 @@ class Message < ApplicationRecord
 
   def direction
     inbound_status? ? :inbound : :outbound
+  end
+
+  def nullify_last_message
+    self.conversation.update_column(:last_message_id, nil)
+    save!
   end
 end

--- a/test/controllers/contacts_controller_test.rb
+++ b/test/controllers/contacts_controller_test.rb
@@ -162,15 +162,15 @@ class ContactsControllerTest < ActionDispatch::IntegrationTest
   test "should destroy contact and associated records" do
     @message = create(:inbound_message, content: "0123456789" * 15)
     @contact.conversation.messages << @message
-  
+
     assert_not_nil Contact.find_by(id: @contact.id)
     assert_not_nil Conversation.find_by(id: @contact.conversation.id)
     assert_not_nil Message.find_by(id: @message.id)
     assert_not_nil @contact.conversation.last_message_id
-  
-    assert_difference('Contact.count', -1) do
-      assert_difference('Conversation.count', -1) do
-        assert_difference('Message.count', -1) do
+
+    assert_difference("Contact.count", -1) do
+      assert_difference("Conversation.count", -1) do
+        assert_difference("Message.count", -1) do
           delete team_contact_url(@team, @contact)
           assert_response :redirect
           follow_redirect!

--- a/test/controllers/contacts_controller_test.rb
+++ b/test/controllers/contacts_controller_test.rb
@@ -150,12 +150,35 @@ class ContactsControllerTest < ActionDispatch::IntegrationTest
 
   test "should destroy contact" do
     team = @contact.team
+    @message = create(:outbound_message, conversation: @contact.conversation)
 
     assert_difference("Contact.count", -1) do
       delete team_contact_url(@team, @contact)
     end
 
     assert_redirected_to team_contacts_url(team)
+  end
+
+  test "should destroy contact and associated records" do
+    @message = create(:inbound_message, content: "0123456789" * 15)
+    @contact.conversation.messages << @message
+  
+    assert_not_nil Contact.find_by(id: @contact.id)
+    assert_not_nil Conversation.find_by(id: @contact.conversation.id)
+    assert_not_nil Message.find_by(id: @message.id)
+    assert_not_nil @contact.conversation.last_message_id
+  
+    assert_difference('Contact.count', -1) do
+      assert_difference('Conversation.count', -1) do
+        assert_difference('Message.count', -1) do
+          delete team_contact_url(@team, @contact)
+          assert_response :redirect
+          follow_redirect!
+          assert_response :success
+          assert_match I18n.t(".contacts.destroy.success"), response.body
+        end
+      end
+    end
   end
 
   test "should search contacts by name" do


### PR DESCRIPTION
Fixes #252 

This error seems to appear only when a conversation contain an inbound message

Changes:

- Remove `last_message_id` from conversation when deleting a message
- Add test with inbound message before deleting a contact