### PR TITLE
Improve management of message status

### DIFF
--- a/app/assets/stylesheets/components/_messages.scss
+++ b/app/assets/stylesheets/components/_messages.scss
@@ -88,6 +88,8 @@
 }
 
 .Message--submitted,
+.Message--failed,
+.Message--expired,
 .Message--rejected,
 .Message--undeliverable {
   .Message__status {

--- a/app/avo/resources/message.rb
+++ b/app/avo/resources/message.rb
@@ -13,8 +13,8 @@ class Avo::Resources::Message < Avo::BaseResource
         info: :submitted, # blue
         success: [ :delivered, :inbound ], # green
         warning: :undeliverable, # yellow
-        danger: :rejected, # red
-        neutral: :unsent # gray
+        danger: [ :rejected, :failed, :expired ], # red
+        neutral: [ :unsent, :deleted ] # gray
       },
       sortable: true
     field :conversation, as: :belongs_to

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -30,7 +30,10 @@ class Message < ApplicationRecord
     submitted: "submitted",
     delivered: "delivered",
     rejected: "rejected",
-    undeliverable: "undeliverable"
+    undeliverable: "undeliverable",
+    expired: "expired",
+    failed: "failed",
+    deleted: "deleted"
   }, suffix: true
 
   belongs_to :conversation, touch: true

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -270,6 +270,8 @@ fr:
       inbound: "Reçu"
       undeliverable: &message_error "Message non distribué"
       rejected: *message_error
+      failed: *message_error
+      expired: *message_error
       submitted: "Envoi en cours..."
       delivered: "Envoyé"
 

--- a/db/migrate/20240910132313_update_message_status_enum.rb
+++ b/db/migrate/20240910132313_update_message_status_enum.rb
@@ -1,0 +1,17 @@
+class UpdateMessageStatusEnum < ActiveRecord::Migration[7.1]
+  def up
+    execute <<-SQL
+      ALTER TYPE message_status ADD VALUE 'expired';
+      ALTER TYPE message_status ADD VALUE 'failed';
+      ALTER TYPE message_status ADD VALUE 'deleted';
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TYPE message_status DROP VALUE 'expired';
+      ALTER TYPE message_status DROP VALUE 'failed';
+      ALTER TYPE message_status DROP VALUE 'deleted';
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_29_135206) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_10_132313) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
-  create_enum "message_status", ["inbound", "unsent", "submitted", "delivered", "rejected", "undeliverable"]
+  create_enum "message_status", ["inbound", "unsent", "submitted", "delivered", "rejected", "undeliverable", "expired", "failed", "deleted"]
   create_enum "user_role", ["user", "team_admin", "site_admin", "super_admin"]
 
   create_table "contacts", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -270,6 +270,33 @@ messages = [
   },
   {
     id: 7,
+    content: "Je suis un message de test status: expired",
+    status: "expired",
+    created_at: DateTime.now.utc,
+    conversation_id: 1,
+    sender_type: "User",
+    sender_id: 4
+  },
+  {
+    id: 8,
+    content: "Je suis un message de test status: failed",
+    status: "failed",
+    created_at: DateTime.now.utc,
+    conversation_id: 1,
+    sender_type: "User",
+    sender_id: 4
+  },
+  {
+    id: 9,
+    content: "Je suis un message de test status: deleted",
+    status: "deleted",
+    created_at: DateTime.now.utc,
+    conversation_id: 1,
+    sender_type: "User",
+    sender_id: 4
+  },
+  {
+    id: 10,
     content: "Je suis un message de test status: inbound",
     status: "inbound",
     created_at: DateTime.now.utc.years_ago(1),
@@ -278,7 +305,7 @@ messages = [
     sender_id: 6
   },
   {
-    id: 8,
+    id: 11,
     content: "Je suis un message de test status: delivered",
     status: "delivered",
     created_at: DateTime.now.utc.years_ago(1),

--- a/test/controllers/outbound_messages_controller_test.rb
+++ b/test/controllers/outbound_messages_controller_test.rb
@@ -20,4 +20,9 @@ class OutboundMessagesControllerTest < ActionDispatch::IntegrationTest
     post outbound_messages_path, params: { message_uuid: SecureRandom.uuid, status: "delivered" }
     assert_response :too_early
   end
+
+  test "should return too early if message_uuid is missing" do
+    post outbound_messages_path, params: { status: "delivered" }
+    assert_response :too_early
+  end
 end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -39,6 +39,23 @@ class MessageTest
       assert_equal(message_from_user.direction, :outbound)
       assert_equal(message_from_contact.direction, :inbound)
     end
+
+    def test_valid_statuses
+      valid_statuses = %w[inbound unsent submitted delivered rejected undeliverable expired failed deleted]
+      message = Message.new(content: "Test content", conversation: create(:conversation), sender: create(:contact))
+  
+      valid_statuses.each do |status|
+        message.status = status
+        assert message.valid?
+      end
+    end
+
+    def test_invalid_status
+      message = Message.new(content: "Test content", conversation: create(:conversation), sender: create(:contact))
+      assert_raises ArgumentError do
+        message.status = "invalid_status"
+      end
+    end
   end
 
   class MessageValidations < ActiveSupport::TestCase
@@ -57,5 +74,15 @@ class MessageTest
       assert(m.valid?)
       assert(m.content == content)
     end
+
+    def test_nullify_last_message
+      message = create(:outbound_message)
+      conversation = message.conversation
+  
+      conversation.update(last_message_id: message.id)
+      message.destroy
+  
+      assert_nil conversation.reload.last_message_id
+    end  
   end
 end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -43,7 +43,7 @@ class MessageTest
     def test_valid_statuses
       valid_statuses = %w[inbound unsent submitted delivered rejected undeliverable expired failed deleted]
       message = Message.new(content: "Test content", conversation: create(:conversation), sender: create(:contact))
-  
+
       valid_statuses.each do |status|
         message.status = status
         assert message.valid?
@@ -78,11 +78,11 @@ class MessageTest
     def test_nullify_last_message
       message = create(:outbound_message)
       conversation = message.conversation
-  
+
       conversation.update(last_message_id: message.id)
       message.destroy
-  
+
       assert_nil conversation.reload.last_message_id
-    end  
+    end
   end
 end


### PR DESCRIPTION
Fixes #248

## Description
It appears that some messages remain "En cours d'envoi..." whhereas in Vonage logs, the message is then in "Expired" status. This is due to the fact that not all the status are handle. See [Vonage doc about it](https://api.support.vonage.com/hc/en-us/articles/360018438551-DLR-Statuses)

## Changes

- Add `expired`, `failed` and `deleted` status
- Db migration following status addition to enum
- Add seeds and tests
- Add the new status in Avo:
<img width="131" alt="Screenshot 2024-09-11 at 15 58 32" src="https://github.com/user-attachments/assets/164748f0-7b2a-4e96-98bd-f3773771b02b">

## Notes

- We should add a case for invalid or unknow status
- The `deleted` status is not managed in the interface, I'm not sure if it's necessary and if so how to manage it.