### PR TITLE
Fix truncate for nil fields

### DIFF
--- a/app/avo/resources/contact.rb
+++ b/app/avo/resources/contact.rb
@@ -6,9 +6,6 @@ class Avo::Resources::Contact < Avo::BaseResource
     field :name, as: :text
     field :email, as: :text
     field :phone, as: :text
-    field :notes,
-      as: :text,
-      format_using: -> { value.truncate 30 }
     field "team", as: :text do
       record.team.name
     rescue
@@ -25,6 +22,7 @@ class Avo::Resources::Contact < Avo::BaseResource
       field :notes_updated_at,
         as: :date,
         format: "yyyy-LL-dd"
+      field :notes, as: :text
       field :notes_last_editor, as: :text
     end
   end


### PR DESCRIPTION
When notes fields is empty it's create an error on avo:
`undefined method `truncate' for nil`