### PR TITLE
Fixed error when sending an empty message

### DIFF
--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag "new_message", target: "_top" do %>
-  <%= form_with(model: @message, class: "MessageForm",
+  <%= form_with(model: @message, url: messages_path, class: "MessageForm",
     data: {
       controller: "message-box",
       action: "turbo:submit-start->message-box#beforeSubmit

--- a/test/controllers/outbound_messages_controller_test.rb
+++ b/test/controllers/outbound_messages_controller_test.rb
@@ -25,4 +25,11 @@ class OutboundMessagesControllerTest < ActionDispatch::IntegrationTest
     post outbound_messages_path, params: { status: "delivered" }
     assert_response :too_early
   end
+
+  test "should handle failed outbound message submission" do
+    post outbound_messages_path, params: { message_uuid: @message.outbound_uuid, status: "failed" }
+
+    assert_equal "failed", @message.reload.status
+    assert_response :ok
+  end
 end

--- a/test/services/outbound_messages_service_test.rb
+++ b/test/services/outbound_messages_service_test.rb
@@ -20,13 +20,69 @@ class OutboundMessagesServiceTest < ActiveSupport::TestCase
   def test_submits_message_to_service
     @provider.expect(
       :send,
-      Struct.new(:message_uuid).new("abc-abc"),
+      OpenStruct.new(message_uuid: :message_uuid, http_response: Net::HTTPSuccess.new(1.0, "200", "OK")),
       from: Current.phone_number, to: @contact.phone, content: "Lorem Ipsum"
     )
 
     assert(@outbound_message.submit!)
     assert(@outbound_message.message.submitted_status?)
     assert(@outbound_message.message.valid?)
+
+    @provider.verify
+  end
+
+  def test_submits_message_to_service_unavailable
+    @provider.expect(
+      :send,
+      OpenStruct.new(message_uuid: :message_uuid, http_response: Net::HTTPServiceUnavailable.new(1.1, "503", "Service Unavailable")),
+      from: Current.phone_number, to: @contact.phone, content: "Lorem Ipsum"
+    )
+
+    assert_not(@outbound_message.submit!)
+    assert(@outbound_message.message.failed_status?)
+    assert(@outbound_message.message.save!)
+
+    @provider.verify
+  end
+
+  def test_submits_message_to_service_bad_request
+    @provider.expect(
+      :send,
+      OpenStruct.new(message_uuid: :message_uuid, http_response: Net::HTTPBadRequest.new(1.1, "400", "Bad Request")),
+      from: Current.phone_number, to: @contact.phone, content: "Lorem Ipsum"
+    )
+
+    assert_not(@outbound_message.submit!)
+    assert(@outbound_message.message.failed_status?)
+    assert(@outbound_message.message.save!)
+
+    @provider.verify
+  end
+
+  def test_submits_message_to_service_unauthorized
+    @provider.expect(
+      :send,
+      OpenStruct.new(message_uuid: :message_uuid, http_response: Net::HTTPUnauthorized.new(1.1, "401", "Unauthorized")),
+      from: Current.phone_number, to: @contact.phone, content: "Lorem Ipsum"
+    )
+
+    assert_not(@outbound_message.submit!)
+    assert(@outbound_message.message.failed_status?)
+    assert(@outbound_message.message.save!)
+
+    @provider.verify
+  end
+
+  def test_submits_message_to_service_server_error
+    @provider.expect(
+      :send,
+      OpenStruct.new(message_uuid: :message_uuid, http_response: Net::HTTPInternalServerError.new(1.1, "500", "Internal Server Error")),
+      from: Current.phone_number, to: @contact.phone, content: "Lorem Ipsum"
+    )
+
+    assert_not(@outbound_message.submit!)
+    assert(@outbound_message.message.failed_status?)
+    assert(@outbound_message.message.save!)
 
     @provider.verify
   end


### PR DESCRIPTION
Fixes #264

## Description
When a user try to send an empty message it is created an `ActiveRecord::RecordInvalid error`

## Changes
Add a condition to save a message only if the content is not empty
