### PR TITLE
Feature: add a description for button or link icons

### DIFF
--- a/app/helpers/teams_helper.rb
+++ b/app/helpers/teams_helper.rb
@@ -13,7 +13,9 @@ module TeamsHelper
         tab_bar_target: "tab",
         turbo_action: :advance
       },
-      class: link_class
+      class: link_class,
+      aria_label: t(".#{label}"),
+      title: t(".#{label}")
   end
 
   def menu_for(label, icon:, destination:, frame: :primary)

--- a/app/views/application/_feedback_button.html.erb
+++ b/app/views/application/_feedback_button.html.erb
@@ -1,5 +1,6 @@
 <button class="cm-btn cm-icon-info cm-btn--floating cm-btn--sm"
   data-tally-open="mOPJ5k" data-tally-emoji-text="👋" data-tally-emoji-animation="wave" data-tally-width="384"
   data-user_email="<%= Current.user&.email %>"
-  data-user_agent="<%= request.user_agent %>" data-user_id="<%= Current.user&.id %>" data-user_environment="<%= Rails.env %>">
+  data-user_agent="<%= request.user_agent %>" data-user_id="<%= Current.user&.id %>" data-user_environment="<%= Rails.env %>"
+  aria-label="<%= t(".feedback") %>" title="<%= t(".feedback") %>">
 </button>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -18,11 +18,11 @@
         </ul>
       <% end %>
       <div class="MessageForm__field cm-input-group <%= "cm-input-group--error" if @message.errors.any? %>">
-        <%= form.text_area :content, class: "cm-input cm-input--line #{"cm-input--error" if @message.errors.any?}", placeholder: t(".placeholder"), data: { message_box_target: "textarea" } %>
+        <%= form.text_area :content, class: "cm-input cm-input--line #{"cm-input--error" if @message.errors.any?}", placeholder: t(".placeholder"), data: { message_box_target: "textarea" }, aria_label: t(".placeholder"), title: t(".placeholder") %>
         <%= form.hidden_field :conversation_id %>  
       </div>
       <div class="MessageForm__send">
-        <%= form.button "Envoyer", class: "cm-btn cm-icon-send", type: "submit" %>
+        <%= form.button "Envoyer", class: "cm-btn cm-icon-send", type: "submit", aria_label: t(".send"), title: t(".send") %>
       </div>
       <div class="MessageForm__character_count cm-hint-text" data-message-box-target="counter"></div>
     </div>
@@ -31,7 +31,7 @@
       <div class="FormErrors">
         <p class="cm-error-text"><%= pluralize(@message.errors.count, "error") %> prohibited this message from being saved:</p>
     
-        <ul class="">
+        <ul>
           <% @message.errors.each do |error| %>
             <li><%= error.full_message %></li>
           <% end %>

--- a/app/views/templates/_template.html.erb
+++ b/app/views/templates/_template.html.erb
@@ -14,16 +14,18 @@
                 confirm_details: t(".confirm_delete"),
                 confirm_button: t(".delete")
               },
-              class: "cm-btn cm-icon-bin cm-btn--secondary" %>
+              class: "cm-btn cm-icon-bin cm-btn--secondary",
+              aria_label: t(".delete"), title: t(".delete") %>
         </div>
 
         <div class="Template__copy">
-          <button data-action="clipboard#copy" class="cm-btn cm-icon-copy cm-btn--validate"></button>
+          <button data-action="clipboard#copy" class="cm-btn cm-icon-copy cm-btn--validate" aria-label="<%= t(".copy") %>" title="<%= t(".copy") %>"></button>
         </div>
 
         <div class="Template__edit">
           <%= link_to "", edit_team_user_template_path(@team, user_id: template.user.id, id: template.id),
-              class: "cm-btn cm-icon-pencil cm-btn--validate" %>
+              class: "cm-btn cm-icon-pencil cm-btn--validate",
+              aria_label: t(".edit"), title: t(".edit") %>
         </div>
       </div>
     </div>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -17,7 +17,9 @@
       </div>
     </div>
     <div class="User__actions">
-        <%= link_to edit_team_user_path(Current.team, user.id), class: "cm-btn cm-btn--sm cm-btn--secondary cm-icon-settings" do %>
+        <%= link_to edit_team_user_path(Current.team, user.id),
+            class: "cm-btn cm-btn--sm cm-btn--secondary cm-icon-settings",
+            aria_label: t(".edit"), title: t(".edit") do %>
           <i class="cm-icon-settings cm-icon--sm"></i>
         <% end if can? :update, user %>
     </div>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -34,6 +34,8 @@ fr:
       contacts: "Répertoire"
     header_tab_bar:
       create_account: "Créer mon compte"
+    feedback_button:
+      feedback: "Signaler un problème"
 
   activerecord:
     models:
@@ -160,9 +162,9 @@ fr:
       message: "Écrire un message"
       confirm_destroy: "Supprimer la conversation et tous les messages ?\nCette opération ne pourra pas être annulée."
       destroy: "Supprimer la conversation"
-      notes: "Notes"
     contact_detail:
       edit: "Modifier la fiche"
+      notes: "Notes"
     new:
       new_list: "Nouvelle liste de diffusion"
       new_contact: "Nouveau contact"
@@ -243,6 +245,7 @@ fr:
       delete_user_confirm: "Supprimer le compte ?\nCette opération ne pourra pas être annulée."
       me: "(moi)"
       admin: "(admin)"
+      edit: "Modifier"
     show:
       edit_user: "Modifier le compte"
       delete_user_confirm: "Supprimer le compte ?\nCette opération ne pourra pas être annulée."
@@ -267,6 +270,7 @@ fr:
       attachment: "Ajouter une pièce jointe"
       photo: "Prendre une photo"
       audio: "Enregistrer un message audio"
+      send: "Envoyer"
     status:
       inbound: "Reçu"
       undeliverable: &message_error "Message non distribué"
@@ -299,3 +303,5 @@ fr:
     template:
       confirm_delete: "Voulez-vous vraiment supprimer le modèle ?"
       delete: "Supprimer"
+      copy: "Copier"
+      edit: "Modifier"


### PR DESCRIPTION
Fixes #251

## Description:
If an image doesn't load, it's impossible to know what the buttons are for
`aria-label` has been add to provide an accessible label for screen readers.
`title` has been add to show a tooltip when the button or link is hovered over.

<img width="529" alt="Screenshot 2024-09-26 at 17 08 50" src="https://github.com/user-attachments/assets/b27ed9fe-fd51-4dd1-9184-17cc0e8406bb">
<img width="588" alt="Screenshot 2024-09-26 at 17 09 08" src="https://github.com/user-attachments/assets/1937c350-912f-4932-bcc5-3cc09f391126">
<img width="387" alt="Screenshot 2024-09-26 at 17 09 34" src="https://github.com/user-attachments/assets/f22db50c-3b6b-475e-b095-8bdd85589f17">
<img width="279" alt="Screenshot 2024-09-26 at 17 09 17" src="https://github.com/user-attachments/assets/93274045-5e0c-4e05-999e-29f2cb68c46a">
