### PR TITLE
Add ES Module Shims for support old browser

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,9 @@
     <%# <link href="/dsfr/dsfr.css" rel="stylesheet"> %>
     <%# <link href="/dsfr/utility/utility.css" rel="stylesheet"> %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    
+
+    <script async src="https://ga.jspm.io/npm:es-module-shims@1.10.0/dist/es-module-shims.js" crossorigin="anonymous"></script>
+
     <%= javascript_importmap_tags %>
     <%= hotwire_livereload_tags if Rails.env.development? %>
     <%= yield(:head) %>


### PR DESCRIPTION
Fix #258

[ES Module Shims](https://github.com/guybedford/es-module-shims#usage)

The pollyfil seems to be doing its job:
<img width="911" alt="Screenshot 2024-10-15 at 16 07 00" src="https://github.com/user-attachments/assets/dfa8b9d3-0ce0-4458-8f44-33126c61f170">

- Firefox 90.0 ✅ 
- Firefox 70.0 ❌
- Chromium 87.0.4280.0 ✅
- Edge 113 ✅
- Edge 100 ✅
- Opera 90.0 ✅ 
- Opera 70.0 ❌

The version that don't work are almost 10 years old and I'm not even sure they may not fully support ECMAScript modules and features like `async/await`, `promises` ...