### PR TITLE
Add prefix on css.properties.mask-image to handle some browsers

### DIFF
--- a/app/assets/stylesheets/_modules/_icons.scss
+++ b/app/assets/stylesheets/_modules/_icons.scss
@@ -101,6 +101,7 @@ $icon-names: (
 
   .cm-icon-#{$icon-name}::before,
   .cm-icon-#{$icon-name}::after {
+    -webkit-mask-image: image-url("icons/#{$icon-name}.svg");
     mask-image: image-url("icons/#{$icon-name}.svg");
   }
 }


### PR DESCRIPTION
Fixes #250

css.properties.mask-image requires prefix for some browsers

Note:

- Y a pas de browserlist en effet
- Il existe une gemme [autoprefixer](https://github.com/ai/autoprefixer-rails) je me suis demandé si c'était pas mieux d'installer ça sachant que le problème pourrait ne pas se retrouver que sur les icons mais y a pas mal d'endroit ou c'est prefixer deja dans le css. Du coup j'ai juste ajouter le prefix et ça règle le soucis. WDYT ?