### PR TITLE
Bump avo, puma and 9 more gems closing all open security advisories

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "rails-i18n"
 
 gem "vonage", "~> 7.28"
 
-gem "avo", ">= 3.2.1"
+gem "avo", "~> 3.32"
 
 gem "stackprof"
 gem "sentry-ruby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
       activesupport (>= 6.0.0)
     ansi (1.5.0)
     ast (2.4.3)
-    avo (3.31.2)
+    avo (3.32.1)
       actionview (>= 6.1)
       active_link_to
       activerecord (>= 6.1)
@@ -100,7 +100,7 @@ GEM
       turbo_power (>= 0.6.0)
       view_component (>= 3.7.0)
       zeitwerk (>= 2.6.12)
-    avo-icons (0.1.4)
+    avo-icons (0.2.1)
       inline_svg
     base64 (0.3.0)
     bcrypt (3.1.22)
@@ -155,7 +155,7 @@ GEM
       devise (>= 4.6)
     docile (1.4.1)
     drb (2.2.3)
-    erb (6.0.4)
+    erb (6.0.7)
     erubi (1.13.1)
     factory_bot (6.5.6)
       activesupport (>= 6.1.0)
@@ -168,6 +168,7 @@ GEM
     ffi (1.17.4-x86_64-linux-gnu)
     globalid (1.4.0)
       activesupport (>= 6.1)
+    hana (1.3.7)
     hotwire-livereload (2.1.1)
       actioncable (>= 7.0.0)
       listen (>= 3.0.0)
@@ -181,16 +182,18 @@ GEM
     inline_svg (1.10.0)
       activesupport (>= 3.0)
       nokogiri (>= 1.6)
-    io-console (0.8.2)
+    io-console (0.9.0)
     irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.21.2)
-    json-schema (6.2.0)
-      addressable (~> 2.8)
-      bigdecimal (>= 3.1, < 5)
+    json_schemer (2.5.0)
+      bigdecimal
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
     jwt (3.2.0)
       base64
     language_server-protocol (3.17.0.5)
@@ -216,8 +219,8 @@ GEM
       net-smtp
     marcel (1.2.1)
     matrix (0.4.3)
-    mcp (0.9.2)
-      json-schema (>= 4.1)
+    mcp (0.25.0)
+      json_schemer (>= 2.4)
     meta-tags (2.23.0)
       actionpack (>= 6.0.0)
     mini_mime (1.1.5)
@@ -230,11 +233,11 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    msgpack (1.8.0)
+    msgpack (1.8.4)
     multipart-post (2.4.1)
     net-http-persistent (4.0.8)
       connection_pool (>= 2.2.4, < 4)
-    net-imap (0.6.4)
+    net-imap (0.6.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -262,17 +265,14 @@ GEM
     phony_rails (0.15.0)
       activesupport (>= 3.0)
       phony (>= 2.18.12)
-    pp (0.6.3)
+    pp (0.6.4)
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
-    prop_initializer (0.3.0)
+    prop_initializer (0.4.0)
       zeitwerk (>= 2.6.18)
-    psych (5.3.1)
-      date
-      stringio
     public_suffix (7.0.5)
-    puma (8.0.1)
+    puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -323,16 +323,21 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rdoc (7.2.0)
+    rbs (4.1.2)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
       erb
-      psych (>= 4.0.0)
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
       tsort
     redis (5.4.1)
       redis-client (>= 0.22.0)
     redis-client (0.28.0)
       connection_pool
     regexp_parser (2.11.3)
-    reline (0.6.3)
+    reline (0.7.0)
       io-console (~> 0.5)
     request_store (1.7.0)
       rack (>= 1.4)
@@ -400,6 +405,7 @@ GEM
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       logger
+    simpleidn (0.2.3)
     sorbet-runtime (0.6.13051)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
@@ -412,7 +418,6 @@ GEM
     stackprof (0.2.28)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
-    stringio (3.2.0)
     thor (1.5.0)
     tilt (2.7.0)
     timeout (0.6.1)
@@ -420,7 +425,7 @@ GEM
     turbo-rails (2.0.23)
       actionpack (>= 7.1.0)
       railties (>= 7.1.0)
-    turbo_power (0.7.0)
+    turbo_power (0.8.0)
       turbo-rails (>= 1.3.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -429,7 +434,7 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
-    view_component (4.9.0)
+    view_component (4.12.0)
       actionview (>= 7.1.0)
       activesupport (>= 7.1.0)
       concurrent-ruby (~> 1)
@@ -452,7 +457,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.7.5)
+    zeitwerk (2.8.3)
 
 PLATFORMS
   aarch64-linux
@@ -460,7 +465,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotaterb
-  avo (>= 3.2.1)
+  avo (~> 3.32)
   bcrypt (~> 3.1.20)
   better_errors
   binding_of_caller


### PR DESCRIPTION
Consolidates the remaining Dependabot security bumps into one resolved lockfile, after activestorage (#426), jwt (#409) and websocket-driver (#422) merged individually and the rest began conflicting with each other.

Closes every open advisory on the repository — `bundler-audit` reports no vulnerabilities against 1231 advisories.

| gem | version | severity |
|---|---|---|
| avo | 3.32.1 | critical |
| puma | 8.0.2 | high x2 |
| view_component | 4.12.0 | high, medium |
| mcp | 0.25.0 | high x2, medium x3 |
| concurrent-ruby | 1.3.8 | high, low x2 |
| nokogiri | 1.19.4 | medium, low x6 |
| rails-html-sanitizer | 1.7.1 | medium |
| loofah | 2.25.2 | medium, low x2 |
| net-imap | 0.6.6 | medium x2, low |
| json | 2.21.2 | low |
| msgpack | 1.8.4 | low |

Also constrains avo to `~> 3.32` (was `>= 3.2.1`).
Supersedes #415, #416, #417, #418, #419, #421, #423, #424, #425, #427.