### PR TITLE
Update BUNDLED WITH from 4.0.3 to 4.0.18 to stop bundler version skew

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -503,4 +503,4 @@ RUBY VERSION
   ruby 4.0.6
 
 BUNDLED WITH
-  4.0.3
+  4.0.18


### PR DESCRIPTION
(oops). Should've been part of #436 