### PR TITLE
Authenticate Vonage webhooks and harden the status callback

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem "lograge" # One-line-per-event format logs
 gem "phony_rails"
 gem "rails-i18n"
 
+gem "jwt"
 gem "vonage", "~> 7.28"
 
 gem "avo", "~> 3.32"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -473,6 +473,7 @@ DEPENDENCIES
   faker
   hotwire-livereload (~> 2.1)
   importmap-rails (~> 2.0)
+  jwt
   lograge
   minitest
   minitest-mock

--- a/app/controllers/concerns/vonage_webhook_authentication.rb
+++ b/app/controllers/concerns/vonage_webhook_authentication.rb
@@ -1,0 +1,60 @@
+# Authenticates webhook requests using the JWT that Vonage attaches to them.
+# https://developer.vonage.com/en/getting-started/concepts/webhooks#validating-signed-webhooks
+#
+# The token is signed (HS256) with the account's signature secret, configured
+# via the VONAGE_SIGNATURE_SECRET environment variable or the
+# vonage_signature_secret credential.
+module VonageWebhookAuthentication
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authenticate_webhook!
+  end
+
+  private
+
+  def authenticate_webhook!
+    secret = vonage_signature_secret
+
+    if secret.blank?
+      # Accept the request so that messages are not lost before the secret is
+      # provisioned, but make noise: webhooks are unauthenticated until then.
+      Rails.logger.warn("Vonage signature secret not configured; webhook accepted without authentication")
+      Sentry.capture_message("Vonage signature secret is not configured; webhooks are NOT authenticated")
+      return
+    end
+
+    head :unauthorized unless valid_webhook_signature?(secret)
+  end
+
+  def valid_webhook_signature?(secret)
+    scheme, token = request.authorization&.split(" ", 2)
+    return false unless scheme == "Bearer" && token.present?
+
+    claims, _header = JWT.decode(token, secret, true, algorithm: "HS256")
+    valid_webhook_payload_hash?(claims)
+  rescue JWT::DecodeError
+    false
+  end
+
+  # Vonage includes a payload_hash claim (SHA-256 of the raw JSON body) so the
+  # payload can't be swapped under a valid token.
+  #
+  # The claim is required, not optional: treating a missing claim as valid would
+  # make the binding bypassable, and a captured token would then authenticate any
+  # body. Vonage always sends it, so a token without one is anomalous enough to
+  # report rather than reject silently.
+  def valid_webhook_payload_hash?(claims)
+    if claims["payload_hash"].blank?
+      Sentry.capture_message("Vonage webhook token carried no payload_hash claim; request rejected")
+      return false
+    end
+
+    expected = Digest::SHA256.hexdigest(request.raw_post)
+    ActiveSupport::SecurityUtils.secure_compare(claims["payload_hash"].to_s, expected)
+  end
+
+  def vonage_signature_secret
+    ENV["VONAGE_SIGNATURE_SECRET"].presence || Rails.application.credentials.vonage_signature_secret
+  end
+end

--- a/app/controllers/inbound_messages_controller.rb
+++ b/app/controllers/inbound_messages_controller.rb
@@ -1,5 +1,7 @@
 # Provide a webhook for inbound SMS and messages services.
 class InboundMessagesController < ApplicationController
+  include VonageWebhookAuthentication
+
   skip_before_action :verify_authenticity_token
   skip_before_action :authenticate_user!
   skip_before_action :set_current
@@ -7,12 +9,7 @@ class InboundMessagesController < ApplicationController
 
   wrap_parameters false
 
-  # TODO
-  # Verify JWT token from request.headers["HTTP_AUTHORIZATION"]
-  # perhaps using https://github.com/jwt/ruby-jwt
-
   def create
-    authenticate_message!
     service = InboundMessagesService.new(vonage_params)
     @message = service.message
 
@@ -32,10 +29,6 @@ class InboundMessagesController < ApplicationController
   end
 
   private
-
-  def authenticate_message!
-    Rails.logger.warn "TODO / Missing authentication of inbound messages."
-  end
 
   def vonage_params
     # Raise ActionController::ParameterMissing if any of those is missing.

--- a/app/controllers/outbound_messages_controller.rb
+++ b/app/controllers/outbound_messages_controller.rb
@@ -1,4 +1,7 @@
+# Provide a webhook for message status callbacks from the provider.
 class OutboundMessagesController < ApplicationController
+  include VonageWebhookAuthentication
+
   skip_before_action :verify_authenticity_token
   skip_before_action :authenticate_user!
   skip_before_action :set_current
@@ -6,7 +9,17 @@ class OutboundMessagesController < ApplicationController
 
   wrap_parameters false
 
+  # Statuses the provider is allowed to set through this webhook. Internal
+  # statuses (inbound, unsent, deleted) must never come from a callback.
+  PROVIDER_STATUSES = %w[submitted delivered rejected undeliverable expired failed].freeze
+
   def create
+    status = params[:status].to_s
+    unless PROVIDER_STATUSES.include?(status)
+      head :unprocessable_entity
+      return
+    end
+
     @message = Message.find_by(outbound_uuid: params[:message_uuid])
 
     # TODO: Use a queue to fix properly
@@ -16,7 +29,7 @@ class OutboundMessagesController < ApplicationController
       return
     end
 
-    @message.status = params[:status]
+    @message.status = status
 
     if @message.save
       head :ok

--- a/test/controllers/inbound_messages_controller_test.rb
+++ b/test/controllers/inbound_messages_controller_test.rb
@@ -1,6 +1,9 @@
 require "test_helper"
+require_relative "../support/vonage_webhook_signing"
 
 class InboundMessagesControllerTest < ActionDispatch::IntegrationTest
+  include VonageWebhookSigning
+
   setup do
     @previous_strategy = :transaction
     @user = create(:user)
@@ -57,6 +60,81 @@ class InboundMessagesControllerTest < ActionDispatch::IntegrationTest
     post inbound_messages_path, params: { to: fake_number, from: @contact.phone, text: "def" }
 
     assert_equal "def", @contact.conversation.last_message.content
+  ensure
+    DatabaseCleaner.strategy = @previous_strategy
+  end
+
+  test "should accept correctly signed requests when a signature secret is configured" do
+    DatabaseCleaner.strategy = :truncation
+
+    with_signature_secret do
+      body = { to: fake_number, from: @contact.phone, text: "signed" }.to_json
+
+      assert_difference([ "Message.count" ]) do
+        post inbound_messages_path, params: body, headers: signed_webhook_headers(body)
+      end
+      assert_response :created
+    end
+  ensure
+    DatabaseCleaner.strategy = @previous_strategy
+  end
+
+  test "should refuse unsigned requests when a signature secret is configured" do
+    with_signature_secret do
+      assert_no_difference([ "Message.count" ]) do
+        post inbound_messages_path, params: { to: fake_number, from: @contact.phone, text: "abc" }
+      end
+      assert_response :unauthorized
+    end
+  end
+
+  test "should refuse requests signed with the wrong secret" do
+    with_signature_secret do
+      body = { to: fake_number, from: @contact.phone, text: "abc" }.to_json
+
+      post inbound_messages_path, params: body, headers: signed_webhook_headers(body, secret: "wrong-secret")
+      assert_response :unauthorized
+    end
+  end
+
+  test "should refuse requests whose payload does not match the signed payload_hash" do
+    with_signature_secret do
+      body = { to: fake_number, from: @contact.phone, text: "tampered" }.to_json
+      other_hash = Digest::SHA256.hexdigest("something else")
+
+      post inbound_messages_path, params: body, headers: signed_webhook_headers(body, payload_hash: other_hash)
+      assert_response :unauthorized
+    end
+  end
+
+  test "should refuse tokens carrying no payload_hash claim" do
+    with_signature_secret do
+      body = { to: fake_number, from: @contact.phone, text: "unbound" }.to_json
+
+      assert_no_difference([ "Message.count" ]) do
+        post inbound_messages_path, params: body, headers: signed_webhook_headers(body, omit_payload_hash: true)
+      end
+      assert_response :unauthorized
+    end
+  end
+
+  # Until VONAGE_SIGNATURE_SECRET is provisioned the webhook stays open by
+  # design, so that messages are not lost on deploy. That makes this the code
+  # path actually running in production today, and the Sentry alert is the only
+  # thing distinguishing "deliberately open" from "silently unauthenticated".
+  test "should accept unsigned requests and report to Sentry when no signature secret is configured" do
+    DatabaseCleaner.strategy = :truncation
+    captured = []
+
+    Sentry.stub(:capture_message, ->(message) { captured << message }) do
+      assert_difference([ "Message.count" ]) do
+        post inbound_messages_path, params: { to: fake_number, from: @contact.phone, text: "unsigned" }
+      end
+    end
+
+    assert_response :created
+    assert_equal 1, captured.size
+    assert_match(/NOT authenticated/, captured.first)
   ensure
     DatabaseCleaner.strategy = @previous_strategy
   end

--- a/test/controllers/outbound_messages_controller_test.rb
+++ b/test/controllers/outbound_messages_controller_test.rb
@@ -1,6 +1,9 @@
 require "test_helper"
+require_relative "../support/vonage_webhook_signing"
 
 class OutboundMessagesControllerTest < ActionDispatch::IntegrationTest
+  include VonageWebhookSigning
+
   setup do
     @user = create(:user)
     @team = @user.teams.first
@@ -31,5 +34,55 @@ class OutboundMessagesControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal "failed", @message.reload.status
     assert_response :ok
+  end
+
+  test "should refuse unknown statuses" do
+    post outbound_messages_path, params: { message_uuid: @message.outbound_uuid, status: "bogus" }
+
+    assert_response :unprocessable_entity
+    assert_equal "submitted", @message.reload.status
+  end
+
+  test "should refuse internal statuses" do
+    %w[inbound unsent deleted].each do |status|
+      post outbound_messages_path, params: { message_uuid: @message.outbound_uuid, status: }
+
+      assert_response :unprocessable_entity
+      assert_equal "submitted", @message.reload.status
+    end
+  end
+
+  test "should accept correctly signed requests when a signature secret is configured" do
+    with_signature_secret do
+      body = { message_uuid: @message.outbound_uuid, status: "delivered" }.to_json
+
+      post outbound_messages_path, params: body, headers: signed_webhook_headers(body)
+      assert_response :ok
+      assert_equal "delivered", @message.reload.status
+    end
+  end
+
+  test "should refuse unsigned requests when a signature secret is configured" do
+    with_signature_secret do
+      post outbound_messages_path, params: { message_uuid: @message.outbound_uuid, status: "delivered" }
+
+      assert_response :unauthorized
+      assert_equal "submitted", @message.reload.status
+    end
+  end
+
+  # See the equivalent test on InboundMessagesControllerTest: this is the path
+  # that runs in production until the signature secret is provisioned.
+  test "should accept unsigned requests and report to Sentry when no signature secret is configured" do
+    captured = []
+
+    Sentry.stub(:capture_message, ->(message) { captured << message }) do
+      post outbound_messages_path, params: { message_uuid: @message.outbound_uuid, status: "delivered" }
+    end
+
+    assert_response :ok
+    assert_equal "delivered", @message.reload.status
+    assert_equal 1, captured.size
+    assert_match(/NOT authenticated/, captured.first)
   end
 end

--- a/test/support/vonage_webhook_signing.rb
+++ b/test/support/vonage_webhook_signing.rb
@@ -1,0 +1,28 @@
+# Helpers to exercise webhook endpoints with (in)valid Vonage JWT signatures.
+module VonageWebhookSigning
+  SIGNATURE_SECRET = "test-signature-secret"
+
+  # Runs the block with webhook authentication enabled.
+  def with_signature_secret(secret = SIGNATURE_SECRET)
+    ENV["VONAGE_SIGNATURE_SECRET"] = secret
+    yield
+  ensure
+    ENV.delete("VONAGE_SIGNATURE_SECRET")
+  end
+
+  # Headers for a signed JSON webhook request whose raw body is +body+.
+  # Pass omit_payload_hash: true to forge an otherwise-valid token that carries
+  # no payload_hash claim, i.e. one not bound to any particular body.
+  def signed_webhook_headers(body, secret: SIGNATURE_SECRET, payload_hash: nil, omit_payload_hash: false)
+    claims = {
+      api_key: "test-api-key",
+      iat: Time.now.to_i,
+      jti: SecureRandom.uuid
+    }
+    claims[:payload_hash] = payload_hash || Digest::SHA256.hexdigest(body) unless omit_payload_hash
+    {
+      "Authorization" => "Bearer #{JWT.encode(claims, secret, "HS256")}",
+      "CONTENT_TYPE" => "application/json"
+    }
+  end
+end


### PR DESCRIPTION
Both webhooks were unauthenticated. `InboundMessagesController#authenticate_message!` logged a TODO and returned, so anyone able to reach the app could inject messages into real conversations, and `OutboundMessagesController` assigned `params[:status]` straight into the enum, so anyone holding a message UUID could set internal statuses such as `deleted`.

Adds a `VonageWebhookAuthentication` concern verifying Vonage's signed JWT (HS256, with the algorithm pinned explicitly so a token declaring `alg: none` cannot bypass verification) and the `payload_hash` claim binding the token to the request body. The status callback now only accepts statuses a provider can legitimately report.

Two changes on top of the original branch, from review:

- The `payload_hash` claim is required rather than optional. Treating a missing claim as valid made the body binding bypassable: a captured token would authenticate any payload. A token without the claim is now rejected and reported, since Vonage always sends one.
- The unauthenticated fallback path is now tested on both controllers. Until `VONAGE_SIGNATURE_SECRET` is provisioned the webhooks stay open by design so messages are not lost on deploy, which makes that the path actually running in production — and the Sentry alert is the only thing separating "deliberately open" from "silently unauthenticated". Both tests assert the alert fires.

Deliberately not included: a guard preventing status regressions from out-of-order provider callbacks. It belongs as a Message validation covering every write path rather than one controller, and terminal states cannot be defined cleanly until `expired` is split into the provider's meaning and our own.

231 runs, 604 assertions, 0 failures. Requires `VONAGE_SIGNATURE_SECRET` to be provisioned before it authenticates anything.