### PR TITLE
Restrict Sentry to production and staging environments

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,11 +1,6 @@
 Sentry.init do |config|
   config.dsn = "https://4fadcf943f15d1ca6827eb2510f467e0@o4507402586357760.ingest.de.sentry.io/4507402590093392"
 
-  # Without this, Sentry initialises in every environment: test runs and local
-  # development send real events to the production project, and each process
-  # attempts an HTTPS flush on exit. Beyond the noise, it devalues the alerts we
-  # rely on as actual signals — the unauthenticated-webhook warning in
-  # VonageWebhookAuthentication being the one that matters most right now.
   config.enabled_environments = %w[production staging]
 
   config.breadcrumbs_logger = [ :active_support_logger, :http_logger ]

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,13 @@
 Sentry.init do |config|
   config.dsn = "https://4fadcf943f15d1ca6827eb2510f467e0@o4507402586357760.ingest.de.sentry.io/4507402590093392"
+
+  # Without this, Sentry initialises in every environment: test runs and local
+  # development send real events to the production project, and each process
+  # attempts an HTTPS flush on exit. Beyond the noise, it devalues the alerts we
+  # rely on as actual signals — the unauthenticated-webhook warning in
+  # VonageWebhookAuthentication being the one that matters most right now.
+  config.enabled_environments = %w[production staging]
+
   config.breadcrumbs_logger = [ :active_support_logger, :http_logger ]
 
   config.traces_sample_rate = 0.05


### PR DESCRIPTION
Closes #438.

`Sentry.init` ran in every environment, so test runs and local development sent real events to the production project and every process attempted an HTTPS flush on exit — visible as `Net::OpenTimeout` stack traces throughout the test output.

The noise matters more than usual right now: #440 leaves the Vonage webhooks deliberately open until `VONAGE_SIGNATURE_SECRET` is provisioned, and a Sentry alert is the only thing distinguishing that from being silently unauthenticated. That alert should not be competing with events from developer machines and CI.

Verified:

- test environment reports `sending_allowed=false`
- `enabled_environments` resolves to `["production", "staging"]`, and `config/environments/staging.rb` exists, so `Rails.env` is literally `staging` on that app and remains covered
- 220 runs / 0 failures, rubocop clean, and no Sentry stack traces in the output

The failure mode worth checking on staging is the inverse of the bug: that events still arrive after the change. A green suite cannot show that.