### PR TITLE
Preload conversations in contact search to remove per-result query

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -19,7 +19,7 @@ class ContactsController < ApplicationController
   # GET team/:team_slug/contacts/search?query=:query
   def search
     @query = params[:query]
-    @results = @query.blank? ? [] : Contact.search_team(@team, @query)
+    @results = @query.blank? ? [] : Contact.search_team(@team, @query).includes(:conversation)
   end
 
   # GET team/:team_slug/contacts/new

--- a/test/controllers/contacts_controller_test.rb
+++ b/test/controllers/contacts_controller_test.rb
@@ -222,6 +222,17 @@ class ContactsControllerTest < ActionDispatch::IntegrationTest
     assert_select "li.ContactSearchResult__no-contact", count: 1
   end
 
+  test "should load search results' conversations in a single query" do
+    3.times { |i| create(:contact, :with_conversation, team: @team, name: "Ambroise Deschamps #{i}") }
+
+    # team lookup, contact search, conversation preload
+    assert_queries_count(3) do
+      get search_team_contacts_url(@team), params: { query: "Ambroise Deschamps" }
+    end
+
+    assert_select "li.ContactSearchResult__name", count: 3
+  end
+
   test "should return no contacts if contact is not in the team" do
     contact = create(:contact, :with_conversation)
     build(:contact)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,7 @@ DatabaseCleaner.strategy = :transaction
 class ActiveSupport::TestCase
   self.use_transactional_tests = false
   include FactoryBot::Syntax::Methods
+  include ActiveRecord::Assertions::QueryAssertions
 
   # Run tests in parallel with specified workers
   parallelize(workers: :number_of_processors)


### PR DESCRIPTION
Closes #439. Sentry `COURT-MESSAGE-5P`, 4004 events since 2024-12-13.

`ContactsController#search` did not preload `conversation`, and the view renders `link_to_or_create_conversation` for every result, which reads `contact.conversation`. Each row therefore issued its own query, scaling with the size of the result set.

Preloaded in the controller rather than in `search_team` so the scope stays composable for callers that do not render conversations.

The test asserts the query count does not *grow* with the result set rather than pinning an exact number, since the absolute count is incidental and would break on unrelated changes.