### PR TITLE
Report rejected Vonage webhooks at warning level with a shared fingerprint

### DIFF
--- a/app/controllers/concerns/vonage_webhook_authentication.rb
+++ b/app/controllers/concerns/vonage_webhook_authentication.rb
@@ -7,6 +7,11 @@
 module VonageWebhookAuthentication
   extend ActiveSupport::Concern
 
+  # All rejections share one fingerprint so they group into a single Sentry
+  # issue: this endpoint is public and collects unauthenticated scanner traffic,
+  # which would otherwise drown the signal in one issue per request.
+  REJECTION_FINGERPRINT = [ "vonage-webhook-signature-rejected" ].freeze
+
   included do
     before_action :authenticate_webhook!
   end
@@ -24,34 +29,39 @@ module VonageWebhookAuthentication
       return
     end
 
-    head :unauthorized unless valid_webhook_signature?(secret)
+    reason = webhook_signature_failure(secret)
+    reject_webhook!(reason) if reason
   end
 
-  def valid_webhook_signature?(secret)
+  # Returns nil when the request is authentic, otherwise a short reason.
+  def webhook_signature_failure(secret)
     scheme, token = request.authorization&.split(" ", 2)
-    return false unless scheme == "Bearer" && token.present?
+    return "no bearer token" unless scheme == "Bearer" && token.present?
 
     claims, _header = JWT.decode(token, secret, true, algorithm: "HS256")
-    valid_webhook_payload_hash?(claims)
-  rescue JWT::DecodeError
-    false
-  end
 
-  # Vonage includes a payload_hash claim (SHA-256 of the raw JSON body) so the
-  # payload can't be swapped under a valid token.
-  #
-  # The claim is required, not optional: treating a missing claim as valid would
-  # make the binding bypassable, and a captured token would then authenticate any
-  # body. Vonage always sends it, so a token without one is anomalous enough to
-  # report rather than reject silently.
-  def valid_webhook_payload_hash?(claims)
-    if claims["payload_hash"].blank?
-      Sentry.capture_message("Vonage webhook token carried no payload_hash claim; request rejected")
-      return false
-    end
+    # Vonage binds the token to the body with a payload_hash claim (SHA-256 of
+    # the raw JSON). Accepting a token without one would make that binding
+    # bypassable, so it is required rather than optional.
+    return "no payload_hash claim" if claims["payload_hash"].blank?
 
     expected = Digest::SHA256.hexdigest(request.raw_post)
-    ActiveSupport::SecurityUtils.secure_compare(claims["payload_hash"].to_s, expected)
+    return "payload_hash mismatch" unless ActiveSupport::SecurityUtils.secure_compare(claims["payload_hash"].to_s, expected)
+
+    nil
+  rescue JWT::DecodeError => e
+    "invalid token (#{e.class})"
+  end
+
+  def reject_webhook!(reason)
+    Rails.logger.warn("Vonage webhook rejected: #{reason}")
+    Sentry.capture_message(
+      "Vonage webhook signature rejected",
+      level: :warning,
+      fingerprint: REJECTION_FINGERPRINT,
+      extra: { reason:, path: request.path }
+    )
+    head :unauthorized
   end
 
   def vonage_signature_secret

--- a/test/controllers/inbound_messages_controller_test.rb
+++ b/test/controllers/inbound_messages_controller_test.rb
@@ -107,6 +107,23 @@ class InboundMessagesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "should report rejected webhooks to Sentry at warning level" do
+    reported = []
+
+    with_signature_secret do
+      Sentry.stub(:capture_message, ->(message, **opts) { reported << [ message, opts ] }) do
+        post inbound_messages_path, params: { to: fake_number, from: @contact.phone, text: "abc" }
+      end
+    end
+
+    assert_response :unauthorized
+    message, opts = reported.sole
+    assert_match(/signature rejected/, message)
+    assert_equal :warning, opts[:level]
+    assert_equal VonageWebhookAuthentication::REJECTION_FINGERPRINT, opts[:fingerprint]
+    assert_equal "no bearer token", opts.dig(:extra, :reason)
+  end
+
   test "should refuse tokens carrying no payload_hash claim" do
     with_signature_secret do
       body = { to: fake_number, from: @contact.phone, text: "unbound" }.to_json


### PR DESCRIPTION
Signature failures were silent. `head :unauthorized` is not an exception, so sentry-rails never saw it, and the only reported cases were "secret not configured" and "token without payload_hash". The alerting was backwards: loud when authentication is off, silent when authentication is failing — and failing is the worse state, because it means inbound messages are being dropped.

Every rejection now logs the reason and reports to Sentry.

Two deliberate choices:

- **Level is `warning`, not `error`.** The endpoint is public and collects scanner traffic, so individual rejections are background noise. What matters is the rate: a sustained spike means Vonage's signing changed and real messages are being lost. This also keeps "notify me on errors" usable as a rule, since a rejected webhook should not page anyone.
- **One shared fingerprint** so rejections group into a single Sentry issue rather than one per request. Without it a scanner sweep would create hundreds of issues.

The reason (`no bearer token`, `invalid token (…)`, `no payload_hash claim`, `payload_hash mismatch`) goes in `extra` rather than the message, so grouping holds while the cause stays visible.

Also folds the payload_hash rejection into the same path — it was reporting separately at error level for a case that essentially never occurs.

Not covered here: detecting that inbound messages have stopped arriving for any reason at all, which catches Vonage outages and routing bugs as well as auth. That belongs with the health-check work.

233 runs / 0 failures, rubocop clean.