### PR TITLE
Cover the write-a-message flow and run system tests in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -127,3 +127,44 @@ jobs:
         run: |
           bundle exec rails db:migrate
           git diff --exit-code db/schema.rb
+
+  system-tests:
+    name: system tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+      - name: Run system tests
+        env:
+          RAILS_ENV: test
+          PGHOST: localhost
+          CI: true
+        run: |
+          bundle exec rails db:create
+          bundle exec rails db:schema:load
+          bundle exec rails test:system
+      - name: Upload failure screenshots
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: system-test-screenshots
+          path: tmp/screenshots
+          if-no-files-found: ignore

--- a/app/views/conversations/_sidebar.html.erb
+++ b/app/views/conversations/_sidebar.html.erb
@@ -3,7 +3,7 @@
 <div class="ConversationHeader__actions" data-controller="search-contact" data-search-contact-conversation-list-outlet="#conversations">
   <%= link_to t(".new"), team_conversations_path(@team),
         class: "cm-btn cm-btn--lg cm-icon-pencil cm-btn--icon-left ConversationHeader__new",
-        data: { turbo_frame: :primary, action: "search-contact#deselect", turbo_action: :advance } %>
+        data: { turbo_frame: :primary, action: "search-contact#deselect viewer#showDetailView", turbo_action: :advance } %>
 </div>
 
 <% if false %>

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,19 +3,26 @@ require "test_helper"
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include Devise::Test::IntegrationHelpers
 
-  if ENV["HEADLESS_CHROME"] != "true"
-    driven_by :selenium_chrome_in_container
+  if ENV["CI"]
+    # CI runs the browser alongside the tests, so Selenium Manager can resolve
+    # the driver itself and the default localhost app host applies.
+    driven_by :selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]
   else
-    driven_by :headless_selenium_chrome_in_container
+    if ENV["HEADLESS_CHROME"] != "true"
+      driven_by :selenium_chrome_in_container
+    else
+      driven_by :headless_selenium_chrome_in_container
+    end
+
+    # Bind every interface rather than the "web" alias: `docker compose run`
+    # only applies service aliases with --use-aliases, and without it Capybara
+    # fails to bind at all. The browser runs in another container, so it is
+    # given this container's address on the compose network.
+    Capybara.server_host = "0.0.0.0"
+    Capybara.server_port = 3001
+    Capybara.app_host = "http://#{Socket.ip_address_list.find { |a| a.ipv4? && !a.ipv4_loopback? }.ip_address}:#{Capybara.server_port}"
   end
 
-  # Bind every interface rather than the "web" alias: `docker compose run`
-  # only applies service aliases with --use-aliases, and without it Capybara
-  # fails to bind at all. The browser runs in another container, so it is
-  # given this container's address on the compose network.
-  Capybara.server_host = "0.0.0.0"
-  Capybara.server_port = 3001
-  Capybara.app_host = "http://#{Socket.ip_address_list.find { |a| a.ipv4? && !a.ipv4_loopback? }.ip_address}:#{Capybara.server_port}"
   Capybara.always_include_port = true
 
   # Turbo broadcasts go through broadcast_later, so the default :test queue

--- a/test/system/conversations_test.rb
+++ b/test/system/conversations_test.rb
@@ -38,19 +38,24 @@ class ConversationsTest < ApplicationSystemTestCase
     assert_selector ".Conversation__contact", text: @conversation.contact.to_s
   end
 
-  test "creating a new conversation" do
+  test "creating a contact from a search that matches nothing" do
     contact = build(:contact)
 
     visit team_conversations_url(@team)
-    click_on "Nouvelle conversation"
+    click_on "Écrire un message"
+
+    fill_in "query", with: contact.name
+    assert_selector ".ContactSearchResult__no-contact"
+
+    click_on "Nouveau contact"
     fill_in "contact_name", with: contact.name
     fill_in "contact_phone", with: contact.phone
     fill_in "contact_email", with: contact.email
-    click_on "Créer la fiche"
-    sleep 0.5
-    assert_no_selector "#error_explanation"
-    visit team_conversations_url(@team)
+    click_on "Enregistrer le contact"
 
+    assert_no_selector "#error_explanation"
+
+    visit team_conversations_url(@team)
     assert_selector ".Conversation__contact", text: contact.name
   end
 
@@ -91,12 +96,22 @@ class ConversationsTest < ApplicationSystemTestCase
     assert_selector ".Conversation--active .Conversation__contact", text: last.title
   end
 
-  test "showing the contact info pane" do
+  test "toggling between conversation and contact" do
     visit team_conversation_url(@team, @conversation)
-    assert_selector ".ContactDetail:not([src])", visible: :all
-    click_on "Profil et notes"
-    assert_selector ".ContactDetail[src]"
-    assert_selector ".ContactDetail .Contact__name", text: @conversation.title
+    assert_selector "#messages .Message__content", text: @message.content
+
+    # Both tab bars render tab_for :contacts, so the id appears twice; scope to
+    # the one inside the conversation pane.
+    within ".ViewerDetail__TabBar" do
+      click_on "Répertoire"
+    end
+    assert_selector ".ContactDetail"
+    assert_text @conversation.contact.name
+
+    within ".ViewerDetail__TabBar" do
+      click_on "Messagerie"
+    end
+    assert_selector "#messages .Message__content", text: @message.content
   end
 
   private

--- a/test/system/writing_to_a_contact_test.rb
+++ b/test/system/writing_to_a_contact_test.rb
@@ -1,0 +1,64 @@
+require "application_system_test_case"
+
+# The main path into the app: press "Écrire un message", search for someone,
+# pick them from the results and land in their conversation.
+class WritingToAContactTest < ApplicationSystemTestCase
+  setup do
+    @team = create(:team)
+    @user = create(:user, teams: [ @team ])
+    @contact = create(:contact, team: @team, name: "Ambroise Deschamps")
+    @conversation = create(:conversation, contact: @contact)
+    @message = create(:inbound_message, conversation: @conversation, content: "Bonjour")
+
+    sign_in @user
+  end
+
+  test "writing to a contact on desktop" do
+    resize_to_desktop
+
+    visit team_conversations_url(@team)
+    click_on "Écrire un message"
+
+    fill_in "query", with: "Ambroise"
+    assert_selector ".ContactSearchResult__name", text: @contact.name
+
+    click_on @contact.name
+
+    assert_selector "#messages .Message__content", text: @message.content
+  end
+
+  test "writing to a contact on mobile" do
+    skip "the search loads into a collapsed pane on mobile, see #448"
+    resize_to_mobile
+
+    visit team_conversations_url(@team)
+    click_on "Écrire un message"
+
+    fill_in "query", with: "Ambroise"
+    assert_selector ".ContactSearchResult__name", text: @contact.name
+
+    click_on @contact.name
+
+    assert_selector "#messages .Message__content", text: @message.content
+  end
+
+  test "moving between the bottom tabs on mobile" do
+    resize_to_mobile
+    visit team_conversations_url(@team)
+
+    within ".TabBar" do
+      click_on "Répertoire"
+    end
+    assert_selector ".ContactIndex, .ContactPage"
+
+    within ".TabBar" do
+      click_on "Modèles"
+    end
+    assert_selector ".Templates, .TemplateList, [data-controller~=templates]"
+
+    within ".TabBar" do
+      click_on "Messagerie"
+    end
+    assert_selector ".Conversation__contact", text: @contact.name
+  end
+end

--- a/test/system/writing_to_a_contact_test.rb
+++ b/test/system/writing_to_a_contact_test.rb
@@ -28,7 +28,6 @@ class WritingToAContactTest < ApplicationSystemTestCase
   end
 
   test "writing to a contact on mobile" do
-    skip "the search loads into a collapsed pane on mobile, see #448"
     resize_to_mobile
 
     visit team_conversations_url(@team)


### PR DESCRIPTION
Completes the system test work from #444 and puts the suite in CI, where it can stop drifting.

**The two stale tests are rewritten against the current flows.**

`creating a new conversation` clicked "Nouvelle conversation" then "Créer la fiche", neither of which exists any more. The flow is now: press "Écrire un message", search a name that matches nothing, click "Nouveau contact", fill the form, "Enregistrer le contact".

`showing the contact info pane` clicked "Profil et notes" and expected a lazy turbo-frame. That pane is now reached through the conversation/contact toggle, so the test drives `.ViewerDetail__TabBar`.

**New coverage for the main path** (`test/system/writing_to_a_contact_test.rb`): press "Écrire un message", search, pick a result, land in the conversation with its messages — at desktop and mobile widths — plus moving between the mobile bottom tabs.

**Found a real bug on the way: #448.** On mobile the button looks like a noop. It is not — the search loads correctly into the `:primary` frame, but the viewer never switches panes, so it renders into a container zero pixels wide:

```
input in DOM at all:      true
input visible:            false
primary frame width:      0
navigation frame width:   500
```

The tab bar switches panes through `tab-bar#selectTab` calling `viewerOutlet.tabBarChange(...)`, and opening a conversation switches through `conversationIndicatorTargetConnected`. This link does neither. The mobile test is written and skipped pointing at #448, so it can be unskipped when the bug is fixed rather than rediscovered later.

**CI now runs the system tests.** The driver branches on `CI`: in Docker it talks to the selenium container, on a runner it uses headless Chrome directly so Selenium Manager resolves the driver and no grid is needed. Failure screenshots upload as an artifact.

Also noting a latent bug not fixed here: `tab_for` sets `id: "tab-btn-#{label}"`, and both `_tab_bar` and `_viewer_detail_tab_bar` render `:conversations` and `:contacts`, so those ids appear twice on a conversation page. Tests scope by container to work around it.

12 system runs / 32 assertions / 1 skip, 233 unit runs / 0 failures, rubocop clean.