### PR TITLE
Enforce one conversation per contact and fix last_message bookkeeping

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -30,10 +30,9 @@ class ConversationsController < ApplicationController
 
   # POST team/:team_slug/conversations
   def create
-    contact = Contact.find(params[:contact])
-    contact.build_conversation
-    contact.save
-    redirect_to team_conversation_path(@team, contact.conversation), notice: I18n.t(".conversations.create.success")
+    contact = @team.contacts.find(params[:contact])
+    conversation = contact.conversation || contact.create_conversation!
+    redirect_to team_conversation_path(@team, conversation), notice: I18n.t(".conversations.create.success")
   end
 
   # GET team/:team_slug/conversations/1

--- a/app/controllers/inbound_messages_controller.rb
+++ b/app/controllers/inbound_messages_controller.rb
@@ -15,9 +15,8 @@ class InboundMessagesController < ApplicationController
 
     if @message.valid?
       ActiveRecord::Base.transaction do
-        @message.save
+        @message.save!
         @message.conversation.mark_as_unread!
-        @message.conversation.messages << @message
       end
     end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -17,7 +17,6 @@ class MessagesController < ApplicationController
 
     if @message.save
       outbound = OutboundMessagesService.new(@message)
-      @conversation.messages << @message
 
       if outbound.submit!
         respond_to do |format|

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -51,8 +51,10 @@ class Contact < ApplicationRecord
 
   private
 
+  # Assign (rather than update_columns) so the values ride along with the
+  # UPDATE that is already being written.
   def update_notes_information
-    self.update_columns(notes_updated_at: Time.current)
-    self.update_columns(notes_last_editor_id: Current.user.id) if Current.user
+    self.notes_updated_at = Time.current
+    self.notes_last_editor_id = Current.user.id if Current.user
   end
 end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -11,7 +11,7 @@
 #
 # Indexes
 #
-#  index_conversations_on_contact_id       (contact_id)
+#  index_conversations_on_contact_id       (contact_id) UNIQUE
 #  index_conversations_on_last_message_id  (last_message_id)
 #
 # Foreign Keys
@@ -22,7 +22,7 @@
 class Conversation < ApplicationRecord
   belongs_to :contact
   has_one :team, through: :contact
-  has_many :messages, -> { order(created_at: :asc) }, dependent: :destroy, after_add: :set_last_message
+  has_many :messages, -> { order(created_at: :asc) }, dependent: :destroy
   has_and_belongs_to_many :agents, class_name: "User"
 
   belongs_to :last_message, class_name: "Message", optional: true
@@ -60,11 +60,6 @@ class Conversation < ApplicationRecord
   def status = read? ? "read" : "unread"
 
   private
-
-  def set_last_message(message)
-    self.last_message = message
-    save!
-  end
 
   def broadcast_conversation_update
     if unread? # broadcast a new message

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -40,7 +40,8 @@ class Message < ApplicationRecord
   belongs_to :sender, polymorphic: true
   delegate :team, to: :conversation
   after_create :associate_user_with_conversation
-  before_destroy :nullify_last_message
+  after_save :update_conversation_last_message, if: :saved_change_to_conversation_id?
+  before_destroy :reassign_conversation_last_message
 
   validates_presence_of :content
 
@@ -50,16 +51,36 @@ class Message < ApplicationRecord
     inbound_status? ? :inbound : :outbound
   end
 
-  def nullify_last_message
-    self.conversation.update_column(:last_message_id, nil)
-    save!
-  end
-
   private
 
   def associate_user_with_conversation
     if sender_type == "User"
       conversation.agents << sender unless conversation.agents.include?(sender)
     end
+  end
+
+  # Runs when the message is created or moved into a conversation. When it
+  # was moved, the previous conversation must stop pointing at it too.
+  def update_conversation_last_message
+    old_conversation_id, _new_id = saved_change_to_conversation_id
+    detach_last_message_from(Conversation.find_by(id: old_conversation_id)) if old_conversation_id
+
+    conversation.update!(last_message: self)
+  end
+
+  # Point the conversation to the previous message (or nothing) before the
+  # database sees the delete; destroying a non-last message used to clear
+  # Conversation#last_message unconditionally.
+  def reassign_conversation_last_message
+    detach_last_message_from(conversation)
+  end
+
+  def detach_last_message_from(other_conversation)
+    return unless other_conversation
+    # Check the database, not the possibly stale in-memory attribute.
+    return unless Conversation.where(id: other_conversation.id).pick(:last_message_id) == id
+
+    previous = other_conversation.messages.where.not(id: id).reorder(created_at: :desc, id: :desc).first
+    other_conversation.update_column(:last_message_id, previous&.id)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
       get :menu, to: "teams#menu"
     end
 
-    resources :conversations, only: [ :index, :show, :new ] do
+    resources :conversations, only: [ :index, :show, :new, :create ] do
       member do
         patch :status, to: "read_status#update", as: :read_status
        end

--- a/db/migrate/20260707130000_enforce_single_conversation_per_contact.rb
+++ b/db/migrate/20260707130000_enforce_single_conversation_per_contact.rb
@@ -1,0 +1,42 @@
+# A Contact has_one Conversation, but nothing enforced it: creating a
+# conversation for a contact that already had one silently produced a
+# duplicate. Merge any existing duplicates (keeping the most recently
+# updated conversation), then back the association with a unique index.
+class EnforceSingleConversationPerContact < ActiveRecord::Migration[8.1]
+  def up
+    duplicated_contact_ids = select_values(<<~SQL)
+      SELECT contact_id FROM conversations GROUP BY contact_id HAVING COUNT(*) > 1
+    SQL
+
+    duplicated_contact_ids.each do |contact_id|
+      ids = select_values(<<~SQL)
+        SELECT id FROM conversations WHERE contact_id = #{contact_id.to_i} ORDER BY updated_at DESC, id DESC
+      SQL
+      keeper, *duplicates = ids
+      duplicate_list = duplicates.join(", ")
+
+      execute("UPDATE messages SET conversation_id = #{keeper} WHERE conversation_id IN (#{duplicate_list})")
+      execute(<<~SQL)
+        INSERT INTO conversations_users (user_id, conversation_id)
+        SELECT DISTINCT user_id, #{keeper} FROM conversations_users
+        WHERE conversation_id IN (#{duplicate_list})
+        ON CONFLICT DO NOTHING
+      SQL
+      execute("DELETE FROM conversations_users WHERE conversation_id IN (#{duplicate_list})")
+      execute(<<~SQL)
+        UPDATE conversations SET last_message_id = (
+          SELECT id FROM messages WHERE conversation_id = #{keeper} ORDER BY created_at DESC, id DESC LIMIT 1
+        ) WHERE id = #{keeper}
+      SQL
+      execute("DELETE FROM conversations WHERE id IN (#{duplicate_list})")
+    end
+
+    remove_index :conversations, :contact_id
+    add_index :conversations, :contact_id, unique: true
+  end
+
+  def down
+    remove_index :conversations, :contact_id
+    add_index :conversations, :contact_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2024_12_12_162919) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_07_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -43,7 +43,7 @@ ActiveRecord::Schema[8.1].define(version: 2024_12_12_162919) do
     t.bigint "last_message_id"
     t.boolean "read", default: true
     t.datetime "updated_at", null: false
-    t.index ["contact_id"], name: "index_conversations_on_contact_id"
+    t.index ["contact_id"], name: "index_conversations_on_contact_id", unique: true
     t.index ["last_message_id"], name: "index_conversations_on_last_message_id"
   end
 

--- a/test/controllers/conversations_controller_test.rb
+++ b/test/controllers/conversations_controller_test.rb
@@ -100,7 +100,7 @@ class ConversationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should select current conversation" do
-    create_list(:conversation, 3, contact: @contact)
+    create_conversations(3)
     @conversation = create(:conversation, contact: @contact)
 
     get team_conversation_url(@team, @conversation)
@@ -108,7 +108,7 @@ class ConversationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should select conversation marked as :selected" do
-    create_list(:conversation, 3, contact: @contact)
+    create_conversations(3)
     @conversation = create(:conversation, contact: @contact)
 
     get team_conversations_url(@team, selected: @conversation.id)
@@ -145,6 +145,33 @@ class ConversationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
 
     assert_select ".Conversation__contact", text: @other_contact.identifier, count: 0
+  end
+
+
+  test "should create a conversation for a contact" do
+    assert_difference("Conversation.count", 1) do
+      post team_conversations_url(@team), params: { contact: @contact.id }
+    end
+
+    assert_redirected_to team_conversation_url(@team, @contact.reload.conversation)
+  end
+
+  test "should reuse the existing conversation instead of creating a duplicate" do
+    existing = create(:conversation, contact: @contact)
+
+    assert_no_difference("Conversation.count") do
+      post team_conversations_url(@team), params: { contact: @contact.id }
+    end
+
+    assert_redirected_to team_conversation_url(@team, existing)
+  end
+
+  test "should not create a conversation for a contact of another team" do
+    other_contact = create(:contact)
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      post team_conversations_url(@team), params: { contact: other_contact.id }
+    end
   end
 
   private

--- a/test/factories/conversations.rb
+++ b/test/factories/conversations.rb
@@ -11,7 +11,7 @@
 #
 # Indexes
 #
-#  index_conversations_on_contact_id       (contact_id)
+#  index_conversations_on_contact_id       (contact_id) UNIQUE
 #  index_conversations_on_last_message_id  (last_message_id)
 #
 # Foreign Keys

--- a/test/models/conversation_test.rb
+++ b/test/models/conversation_test.rb
@@ -11,7 +11,7 @@
 #
 # Indexes
 #
-#  index_conversations_on_contact_id       (contact_id)
+#  index_conversations_on_contact_id       (contact_id) UNIQUE
 #  index_conversations_on_last_message_id  (last_message_id)
 #
 # Foreign Keys
@@ -125,7 +125,7 @@ class ConversationTest < ActiveSupport::TestCase
     user = create(:user)
     other_user = create(:user)
 
-    team_conversations = create_list(:conversation, 3, contact: create(:contact, team: team))
+    team_conversations = Array.new(3) { create(:conversation, contact: create(:contact, team: team)) }
 
     user_conversations = team_conversations[0..1]
     user.conversations << user_conversations
@@ -139,7 +139,7 @@ class ConversationTest < ActiveSupport::TestCase
     team = create(:team)
     user = create(:user)
 
-    convos = create_list(:conversation, 3, contact: create(:contact, team: team))
+    convos = Array.new(3) { create(:conversation, contact: create(:contact, team: team)) }
     user.conversations << convos
 
     convos.each { |convo| convo.messages << create(:inbound_message) }
@@ -181,8 +181,8 @@ class ConversationTest < ActiveSupport::TestCase
     team_2 = create(:team)
     user = create(:user)
 
-    team_1_conversations = create_list(:conversation, 2, contact: create(:contact, team: team_1))
-    team_2_conversations = create_list(:conversation, 2, contact: create(:contact, team: team_2))
+    team_1_conversations = Array.new(2) { create(:conversation, contact: create(:contact, team: team_1)) }
+    team_2_conversations = Array.new(2) { create(:conversation, contact: create(:contact, team: team_2)) }
 
     user.conversations << team_1_conversations
     user.conversations << team_2_conversations
@@ -204,7 +204,6 @@ class ConversationTest < ActiveSupport::TestCase
       ActiveRecord::Base.transaction do
         message.save!
         conversation.mark_as_unread!
-        conversation.messages << message
       end
     end
   end
@@ -224,7 +223,6 @@ class ConversationTest < ActiveSupport::TestCase
       ActiveRecord::Base.transaction do
         message.save!
         conversation.mark_as_unread!
-        conversation.messages << message
       end
     end
   end
@@ -240,7 +238,6 @@ class ConversationTest < ActiveSupport::TestCase
       ActiveRecord::Base.transaction do
         message.save!
         conversation.mark_as_unread!
-        conversation.messages << message
       end
     end
   end
@@ -256,16 +253,20 @@ class ConversationTest < ActiveSupport::TestCase
     user.conversations << conversation_1
     other_user.conversations << conversation_2
 
-    inbound_message = create(:inbound_message, conversation: conversation_1)
-
     # Add a message to conversation_1 and check broadcast for user
     assert_turbo_stream_broadcasts "user_conversations_list_#{user.id}" do
-      conversation_1.messages << inbound_message
+      ActiveRecord::Base.transaction do
+        create(:inbound_message, conversation: conversation_1)
+        conversation_1.mark_as_unread!
+      end
     end
 
-    # Verify that conversation_2 does not broadcast to user
+    # Verify that conversation_1 does not broadcast to other_user
     assert_no_turbo_stream_broadcasts("user_conversations_list_#{other_user.id}") do
-      conversation_1.messages << create(:inbound_message)
+      ActiveRecord::Base.transaction do
+        create(:inbound_message, conversation: conversation_1)
+        conversation_1.mark_as_unread!
+      end
     end
   end
 
@@ -280,7 +281,10 @@ class ConversationTest < ActiveSupport::TestCase
 
     assert_turbo_stream_broadcasts "user_conversations_list_#{user.id}" do
       assert_turbo_stream_broadcasts "user_conversations_list_#{other_user.id}" do
-        conversation.messages << create(:inbound_message)
+        ActiveRecord::Base.transaction do
+          create(:inbound_message, conversation: conversation)
+          conversation.mark_as_unread!
+        end
       end
     end
   end
@@ -350,5 +354,13 @@ class ConversationTest < ActiveSupport::TestCase
 
     @new_conversation = create(:conversation)
     assert_equal(@new_conversation.updated_at, @new_conversation.timestamp)
+  end
+
+  def test_contact_cannot_have_two_conversations
+    contact = create(:contact, :with_conversation)
+
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      create(:conversation, contact: contact)
+    end
   end
 end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -84,5 +84,33 @@ class MessageTest
 
       assert_nil conversation.reload.last_message_id
     end
+
+    def test_destroying_last_message_reassigns_to_previous_message
+      conversation = create(:conversation)
+      older = create(:outbound_message, conversation:, created_at: 2.hours.ago)
+      newer = create(:outbound_message, conversation:, created_at: 1.hour.ago)
+
+      assert_equal(newer, conversation.reload.last_message)
+      newer.destroy
+
+      assert_equal(older, conversation.reload.last_message)
+    end
+
+    def test_destroying_another_message_keeps_last_message
+      conversation = create(:conversation)
+      older = create(:outbound_message, conversation:, created_at: 2.hours.ago)
+      newer = create(:outbound_message, conversation:, created_at: 1.hour.ago)
+
+      older.destroy
+
+      assert_equal(newer, conversation.reload.last_message)
+    end
+
+    def test_creating_a_message_sets_conversation_last_message
+      conversation = create(:conversation)
+      message = create(:outbound_message, conversation:)
+
+      assert_equal(message, conversation.reload.last_message)
+    end
   end
 end


### PR DESCRIPTION
Closes the double-add in `MessagesController#create` and `InboundMessagesController#create` that threw 500s at users in July, and backs `Contact has_one :conversation` with a unique index.

- `conversation.messages << @message` re-saved an already-saved message; `last_message` is now maintained by a callback on `Message` instead of an `after_add` on the association.
- Destroying a message reassigns `last_message` to the previous one rather than nulling it unconditionally.
- `ConversationsController#create` scopes the contact to the team and reuses an existing conversation; the route was missing `:create`.
- `Contact#update_notes_information` assigns in the `before_update` instead of issuing two extra `update_columns` writes.
- Migration merges any pre-existing duplicate conversations before adding the unique index.

The migration is destructive on duplicates, so it needs a production count before merge.